### PR TITLE
Add custom commands title and option for document size

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -24,6 +24,20 @@
 
 Create an horizontal line.
 
+## section macros
+
+| | `small` | `middle` | `big` |
+|-|---------|----------------|-----|
+|`\LevelOneTitle` | `\section` | `\chapter` | `\part`|
+|`\LevelTwoTitle` | `\subsection` | `\section` | `\chapter`|
+|`\LevelThreeTitle` | `\subsubsection` | `\subsection` | `\section`|
+|`\LevelFourTitle`| `\paragraph` | `\subsubsection` | `\subsection` |
+|`\LevelFiveTitle` |  `\subparagraph` | `\paragraph` | `\subsubsection`|
+|`\LevelSixTitle` | *n.a.* |  `\subparagraph` | `\paragraph` |
+|`\LevelSevenTitle` | *n.a.* | *n.a.* |  `\subparagraph`|
+| `\Introduction` | `\Introduction` | `\Introduction` | 
+| `Conclusion` | `Conclusion` | `Conclusion` |
+
 # Class environements
 
 ## `Information`, `Question`, `Attention` and `Erreur`
@@ -31,3 +45,6 @@ Create an horizontal line.
 Mimick the corresponding markdown blocks.
 
 
+# Class options
+
++ `big`, `middle` or `small` give access to different level of sectioning (see section macros).  

--- a/test.tex
+++ b/test.tex
@@ -122,7 +122,7 @@ element & element & element\\ \hline
 \caption{Légende}
 \end{longtabu}
 
-\Conlusion{Conclusion}
+\Conclusion{Conclusion}
 Conclusion
 
 \end{document}

--- a/test.tex
+++ b/test.tex
@@ -1,4 +1,4 @@
-\documentclass{zmdocument}
+\documentclass[small]{zmdocument}
 
 \usepackage{blindtext}
 
@@ -11,17 +11,17 @@
 \maketitle
 \tableofcontents
 
-\addsec{Introcution}
+\Introduction{Introcution}
 
 Ce message s’adresse principalement aux bon connaisseurs de LaTeX : l’équipe de développement a besoin de vous !
 
-\section{Contexte}
+\LevelOneTitle{Contexte}
 Nous travaillons actuellement sur la refonte de l’outils qui gère la partie MarkDown -> autres formats et nous souhaitons refaire le template actuel LaTeX. Nous utilisons celui de base de Pandoc or cet outil sera remplacé dans le futur. Nous cherchons donc quelques personnes pour nous aider dans la réalisation de macros pour chaque élément spécifique à ZdS.
 
 Si vous avez des questions et/ou si vous êtes intéressés, n’hésitez pas à passer sur IRC ou à laisser un message par ici
 
-\subsection{Les éléments à faire}
-\subsubsection{Ensemble des éléments classiques}
+\LevelTwoTitle{Les éléments à faire}
+\LevelThreeTitle{Ensemble des éléments classiques}
 
 \begin{itemize}
 \item \textbf{Gras}
@@ -49,10 +49,10 @@ Texte aligné à droite
 \item Liste numérotées
 \end{enumerate}
 
-\subsection{Titre}
-\subsubsection{De}
-\paragraph{Toute}
-\subparagraph{taille}
+\LevelTwoTitle{Titre}
+\LevelThreeTitle{De}
+\LevelFourTitle{Toute}
+\LevelFiveTitle{taille}
 
 La suite, avec des touches \keys{CTRL} + \keys{A}. Et on peut avoir une ligne avec
 
@@ -122,7 +122,7 @@ element & element & element\\ \hline
 \caption{Légende}
 \end{longtabu}
 
-\addsec{Conclusion}
+\Conlusion{Conclusion}
 Conclusion
 
 \end{document}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{zmdocument}
 
-\LoadClass[fontsize=12pt,twoside=false,numbers=enddot,parskip=half]{scrartcl}
+\LoadClass[fontsize=12pt,twoside=false,numbers=enddot,parskip=half]{scrbook}
 
 \RequirePackage[utf8]{inputenc}
 \RequirePackage[T1]{fontenc}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -45,7 +45,9 @@
    \let\LevelFiveTitle\subparagraph
    \let\Introduction\addsec
    \let\Conclusion\addsec
-   \def\thesection{\arabic{section}} 
+   \def\thesection{\arabic{section}}
+   \def\thefigure{\arabic{section}} 
+   \def\thetable{\arabic{section}} 
    \automark[subsection]{section}
 }
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -31,8 +31,48 @@
 \RequirePackage[thmmarks,amsmath,hyperref]{ntheorem}
 
 
-
 %%% SECTIONNING 
+
+\lohead{\headmark}
+\chead{}
+\pagestyle{scrheadings}
+   
+\DeclareOption{small}{
+   \let\LevelOneTitle\section
+   \let\LevelTwoTitle\subsection
+   \let\LevelThreeTitle\subsubsection
+   \let\LevelFourTitle\paragraph
+   \let\LevelFiveTitle\subparagraph
+   \let\Introduction\addsec
+   \let\Conclusion\addsec
+   \def\thesection{\arabic{section}} 
+   \automark[subsection]{section}
+}
+
+\DeclareOption{middle}{
+   \let\LevelOneTitle\chapter
+   \let\LevelTwoTitle\section
+   \let\LevelThreeTitle\subsection
+   \let\LevelFourTitle\subsubsection
+   \let\LevelFiveTitle\paragraph
+   \let\LevelSixTitle\subparagaph
+   \let\Introduction\addchap
+   \let\Conclusion\addchap
+   \automark[section]{chapter}
+}
+\DeclareOption{big}{
+   \let\LevelOneTitle\part  
+   \let\LevelTwoTitle\chapter
+   \let\LevelThreeTitle\section
+   \let\LevelFourTitle\subsection
+   \let\LevelFiveTitle\subsubsection
+   \let\LevelSixTitle\paragraph
+   \let\LevelSevenTitle\subparagaph
+   \let\Introduction\addpart
+   \let\Conclusion\addpart
+   \automark[chapter]{part}
+}
+\ProcessOptions
 
 \definecolor{chaptercolor}{HTML}{EA9408}
 \definecolor{sectioncolor}{HTML}{EA9408}
@@ -41,7 +81,7 @@
 \definecolor{paragraphcolor}{HTML}{000000}
 \definecolor{subparagraphcolor}{HTML}{000000}
 
-%\addtokomafont{chapter}{\color{chaptercolor}}
+\addtokomafont{chapter}{\color{chaptercolor}}
 \addtokomafont{section}{\color{sectioncolor}}
 \addtokomafont{subsection}{\color{subsectioncolor}}
 \addtokomafont{subsubsection}{\color{sectioncolor}}


### PR DESCRIPTION
This PR add three class options, `small`, `middle` and `big` and define title commands (fix #6). See the example.