### PR TITLE
Add \abbr{}{} command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
 # LaTeX stuffs:
 *.aux
-*.log 
+*.ist
+*.log
 *.out
 *.pdf
+*.glg
+*.glo
+*.gls
+*.glsdefs
 *.gz
 *.thm
 *.toc
-_minted_test
+*.xdy
+_minted*
 
 # Other craps:
 Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ help:
 	@echo "  help       to get this help"
 
 test:
-	pdflatex -shell-escape -interaction=nonstopmode test.tex
+	-pdflatex -shell-escape -interaction=nonstopmode test.tex
+	-pdflatex -shell-escape -interaction=nonstopmode test.tex
+	-makeglossaries test
+	-pdflatex -shell-escape -interaction=nonstopmode test.tex
 
 clean:
-	rm *.aux *.log *.out *.pdf *.thm *.toc 
+	rm *.aux *.log *.out *.pdf *.thm *.toc *.glg *.glo *.gls *.glsdefs *.ist
 	rm -r _minted-test

--- a/documentation.md
+++ b/documentation.md
@@ -5,36 +5,42 @@
 + Italic: `\textit{text}`
 + Bold: `\textbf{text}`
 + Strikethrough: `\sout{text}`
-+ Superscript and subscripts: `\textsubscript{x}` and `\textsuperscript{x}`
++ Superscript and subscript: `\textsubscript{x}` and `\textsuperscript{x}`
 + Inline source code: "\verb\`text\`"
 + Keys: `\keys{x}`
 + Footnotes: `\footnote{text}`
 + Maths (obviously)
 
-## Environements
+## environments
 
-+ Lists: `itemize` environement for bulleted, `enumerate` environement for numbered. Inside them, each item is defined with `\item`.
-+ Aligned text: text is justifed by default, `flushright` and `center` environements are available to change that.
-+ Code: the `minted` environement.
++ Lists: `itemize` environment for bulleted, `enumerate` environment for numbered. Inside them, each item is defined with `\item`.
++ Aligned text: text is justified by default, `flushright` and `center` environments are available to change that.
++ Code: the `minted` environment.
 
 # Class options
 
-+ `big`, `middle` or `small` give access to different level of sectioning (see section macros below).  
++ `big`, `middle` or `small` give access to different levels of sectioning (see section macros below).  
 + `print` permit to have a document to print. The link are not clickable, there are formatted as **\[text](link)**.
 
 # Class macros
 
+## Abbreviations
+
+To add an abbreviation, use `\abbr{word}{definition}`:. Abbreviations will be in a glossary at the end of the document.
+
+**Disclaimer**: word should not contain accented characters or other special characters because of the *glossaries* package.
+
 ## `\horizontalLine`
 
-Create an horizontal line.
+Create a horizontal line.
 
 ## `\externalLink`
 
-Create a linke with `\externalLink{text}{link}`. 
+Create a link with `\externalLink{text}{link}`.
 
 ## Section macros
 
-The differents title level are adapted depending on the class option.
+The different title levels are adapted depending on the class option.
 
 | | `small` | `middle` | `big` |
 |-|---------|----------------|-----|
@@ -50,9 +56,9 @@ For introduction and conclusion, `\Introduction` and `\Conclusion` are also defi
 
 ## Title page macros (`\website`, `\authorlink`, `\editor` and `\logo`)
 
-These macros shoud be used before `\maketitle` (ideally in the preamble). If they are not used, there are default values. Be careful that `\logo` take in parameter the path of an image (and not an image). The default logo is `default_logo.png`. 
+These macros should be used before `\maketitle` (ideally in the preamble). If they are not used, there are default values. Be careful that `\logo` take in parameter the path of an image (and not an image). The default logo is `default_logo.png`.
 
-If there is multiple authors, use `\author` with a comma-separated list of them: `\author{author1, author2}`. 
+If there is multiple authors, use `\author` with a comma-separated list of them: `\author{author1, author2}`.
 
 ## Smilies
 
@@ -63,25 +69,25 @@ Smilies need two commands to works (which should be defined in the preamble of t
 \smilies{blink,devil} % the different smilies (one smiley = one image)
 ```
 
-Then, the `\xxxSmiley` command is defined in the document, when `xxx` is one of the smiley in `\smilies`. 
+Then, the `\xxxSmiley` command is defined in the document, when `xxx` is one of the smiley in `\smilies`.
 In the above example, it defines `\blinkSmiley` and `\devilSmiley`.
 
 ## Spoilers
 
-To add a spoiler, use `\addSoiler`: `\addSpoiler{Hide text}`. Spoilers will be in a "Spoiler" section (each chapter will have its "Spoiler" section). 
+To add a spoiler, use `\addSpoiler`: `\addSpoiler{Hide text}`. Spoilers will be in a "Spoiler" section (each chapter will have its "Spoiler" section).
 
 ## Iframes
 
-To add an iframe block (for example Youtube videos), use `\iframe`: `\iframe{url}[iframe type][caption]`. 
+To add an iframe block (for example Youtube videos), use `\iframe`: `\iframe{url}[iframe type][caption]`.
 
-Argument in square brackets are optionnal (`\iframe{url}` is enough). The default value of `iframe type` is "Vidéo" and the default value for `caption` is blank.
+Arguments in square brackets are optionnal (`\iframe{url}` is enough). The default value of `iframe type` is "Vidéo" and the default value for `caption` is blank.
 
-# Class environements
+# Class environments
 
 ## `Information`, `Question`, `Warning` and `Error`
 
-Mimick the corresponding markdown blocks.
+Mimic the corresponding markdown blocks.
 
 ## Quotes
 
-The `Quotation` environement takes an extra parameter, being the source of the quote.
+The `Quotation` environment takes an extra parameter, being the source of the quote.

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/dev/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="xpatch minted fvextra ifplatform xstring framed capt-of menukeys multirow longtable tabu adjustbox collectbox relsize tikz ntheorem catoptions varwidth blindtext cm-super"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform longtable menukeys minted multirow ntheorem relsize tabu tikz varwidth xpatch xstring"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/dev/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform longtable menukeys minted multirow ntheorem relsize tabu tikz varwidth xpatch xstring"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform longtable menukeys minted multirow ntheorem relsize tabu varwidth xpatch xstring"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/test.tex
+++ b/test.tex
@@ -9,6 +9,7 @@
 
 \smiliesPath{./test-smilies}
 \smilies{clin,diable}
+\makeglossaries
 
 \begin{document}
 \maketitle
@@ -21,7 +22,8 @@ Ce message s’adresse principalement aux bon connaisseurs de LaTeX : l’équip
 \addSpoiler{Voici un secret.}
 
 \LevelOneTitle{Contexte}
-Nous travaillons actuellement sur la refonte de l’outils qui gère la partie MarkDown -> autres formats et nous souhaitons refaire le template actuel LaTeX. Nous utilisons celui de base de Pandoc or cet outil sera remplacé dans le futur. Nous cherchons donc quelques personnes pour nous aider dans la réalisation de macros pour chaque élément spécifique à ZdS.
+
+Nous travaillons actuellement sur la refonte de l’outils qui gère la partie \abbr{MD}{Markdown} -> autres formats et nous souhaitons refaire le template actuel LaTeX. Nous utilisons celui de base de Pandoc or cet outil sera remplacé dans le futur. Nous cherchons donc quelques personnes pour nous aider dans la réalisation de macros pour chaque élément spécifique à ZdS.
 
 Si vous avez des questions et/ou si vous êtes intéressés, n’hésitez pas à passer sur IRC ou à laisser un message par ici \diableSmiley{}
 
@@ -82,7 +84,7 @@ def foo(bar):
 return 42
 \end{minted}
 
-Une image: 
+Une image:
 
 \begin{center}
 \includegraphics[width=\linewidth]{logo.png}
@@ -147,5 +149,4 @@ element & element & element\\ \hline
 \addSpoiler{On va quand même mettre un secret pour finir.}
 
 Conclusion
-
 \end{document}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -16,7 +16,6 @@
 \RequirePackage{ulem}
 
 \RequirePackage{etoolbox}
-\RequirePackage{xparse}
 
 %%% TABLE PACKAGES
 \RequirePackage{multirow}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -34,7 +34,6 @@
 %%% ABBREVIATIONS PACKAGES
 \RequirePackage{glossaries}
 
-
 %%% COLORS DEFINITION
 
 \definecolor{internallinkcolor}{HTML}{FF9400}
@@ -261,15 +260,9 @@
 
 %%% Abbreviation
 
-\newcommand{\udensdot}[1]{
-    \tikz[baseline=(todotted.base)]{
-        \node[inner sep=2pt,outer sep=0pt] (todotted) {#1};
-        \draw[densely dotted] (todotted.south west) -- (todotted.south east);
-    }
-}
-\newcommand{\abbr}[2]{\udensdot{\gls{#1}}\newglossaryentry{#1}{
-    name=#1,
-    description={#2}
-  }
-}
+\newcommand{\abbr}[2]{\dotuline{\gls{#1}}\newglossaryentry{#1}{
+  name=#1,
+  description={#2}
+}}
+
 \AtEndDocument{\printglossary[title=Liste des abbréviations]}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -16,6 +16,7 @@
 \RequirePackage{ulem}
 
 \RequirePackage{etoolbox}
+\RequirePackage{xparse}
 
 %%% TABLE PACKAGES
 \RequirePackage{multirow}
@@ -207,7 +208,8 @@
    \setcounter{@spoilerCounter}{0}
 }
 
-\AtEndDocument{\displaySpoilers}
+\AtEndDocument{\displaySpoilers
+\printglossary[title=Liste des abbréviations]}
 
 %%%
 
@@ -263,5 +265,3 @@
   name=#1,
   description={#2}
 }}
-
-\AtEndDocument{\printglossary[title=Liste des abbréviations]}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -31,6 +31,9 @@
 \RequirePackage[thmmarks,amsmath,hyperref]{ntheorem}
 \RequirePackage[hyperrefcolorlinks]{menukeys}
 
+%%% ABBREVIATIONS PACKAGES
+\RequirePackage{glossaries}
+
 
 %%% COLORS DEFINITION
 
@@ -66,12 +69,12 @@
 %%%
 
 
-%%% SECTIONNING 
+%%% SECTIONNING
 
 \lohead{\headmark}
 \chead{}
 \pagestyle{scrheadings}
-   
+
 \DeclareOption{small}{
    \let\LevelOneTitle\section
    \let\LevelTwoTitle\subsection
@@ -81,8 +84,8 @@
    \let\Introduction\addsec
    \let\Conclusion\addsec
    \def\thesection{\arabic{section}}
-   \def\thefigure{\arabic{section}} 
-   \def\thetable{\arabic{section}} 
+   \def\thefigure{\arabic{section}}
+   \def\thetable{\arabic{section}}
    \automark[subsection]{section}
 }
 
@@ -158,7 +161,7 @@
 %%% QUOTATION
 
 \newenvironment{Quotation}[1]{
-    \def\quoteAuthor{#1}~\\ 
+    \def\quoteAuthor{#1}~\\
     \begin{minipage}{\linewidth}\begin{QuotationBox}
 }{
     \hfill(\quoteAuthor)
@@ -196,7 +199,7 @@
    \setcounter{@spoilerCounter}{1}
    \ifdefvoid{\@spoilerList}{}{\levelSpoilerTitle{Blocs secrets}}
    \def\do{}
-   \renewcommand{\do}[1]{\hypertarget{secret:\thepart\thechapter\the@spoilerCounter}{} 
+   \renewcommand{\do}[1]{\hypertarget{secret:\thepart\thechapter\the@spoilerCounter}{}
                          \levelSpoiler*{Secret \the@spoilerCounter}
                          \expandafter{##1}\\ \hfill \hyperlink{voir:\thepart\thechapter\the@spoilerCounter}
                                                               {Retourner au texte.}
@@ -245,7 +248,7 @@
 \newcommand{\createSmiley}[1]{\expandafter\def\csname#1Smiley\endcsname{\raisebox{-3pt}{\includegraphics[height=15pt]{\@smiliesPath/#1}} }}
 
 \AtBeginDocument{%
-\renewcommand*{\do}[1]{\createSmiley{#1}} 
+\renewcommand*{\do}[1]{\createSmiley{#1}}
 \expandafter\docsvlist\expandafter{\@smilies}
 }
 
@@ -255,3 +258,18 @@
 \renewcommand{\arraystretch}{1.5}
 
 \newcommand{\horizontalLine}{{\color{gray}\rule{\textwidth}{0.2pt}}}
+
+%%% Abbreviation
+
+\newcommand{\udensdot}[1]{
+    \tikz[baseline=(todotted.base)]{
+        \node[inner sep=2pt,outer sep=0pt] (todotted) {#1};
+        \draw[densely dotted] (todotted.south west) -- (todotted.south east);
+    }
+}
+\newcommand{\abbr}[2]{\udensdot{\gls{#1}}\newglossaryentry{#1}{
+    name=#1,
+    description={#2}
+  }
+}
+\AtEndDocument{\printglossary[title=Liste des abbréviations]}


### PR DESCRIPTION
Hi,

I tried to create an `\abbr` command ( #1 ) . It uses a glossary with a link to navigate between the glossary and the abbreviation.

I made some changes in the Makefile and I removed some trailing spaces.