### PR TITLE
Fix multiple authors issue and add title parameter

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -46,7 +46,7 @@ For introduction and conclusion, `\Introduction` and `\Conclusion` are also defi
 
 ## Title page macros (`\website`, `\authorlink`, `\editor` and `\logo`)
 
-These macros shoud be used before `\maketitle` (ideally in the preamble). If they are not used, there are default values. Be careful that `\logo` take in parameter the path of an image (and not an image).
+These macros shoud be used before `\maketitle` (ideally in the preamble). If they are not used, there are default values. Be careful that `\logo` take in parameter the path of an image (and not an image). The default logo is `default_logo.png`. 
 
 If there is multiple authors, use `\author` with a comma-separated list of them: `\author{author1, author2}`. 
 

--- a/documentation.md
+++ b/documentation.md
@@ -44,6 +44,12 @@ The differents title level are adapted depending on the class option.
 
 For introduction and conclusion, `\Introduction` and `\Conclusion` are also defined.
 
+## Title page macros (`\website`, `\authorlink`, `\editor` and `\logo`)
+
+These macros shoud be used before `\maketitle` (ideally in the preamble). If they are not used, there are default values. Be careful that `\logo` take in parameter the path of an image (and not an image).
+
+If there is multiple authors, use `\author` with a comma-separated list of them: `\author{author1, author2}`. 
+
 # Class environements
 
 ## `Information`, `Question`, `Warning` and `Error`

--- a/test.tex
+++ b/test.tex
@@ -3,7 +3,7 @@
 \usepackage{blindtext}
 
 \title{Ceci est un titre}
-\author{Karnaj}
+\author{Karnaj, Clem}
 \licence{CC-BY-NC-ND}
 \logo{logo.png}
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -130,13 +130,13 @@
 \newcommand{\authorlink}[1]{\def\@authorlink{#1}}
 
 \renewcommand{\maketitle}{%
-   \ifcsdef{\authorlink}{}{\def\@authorlink{https://zestedesavoir.com/membres/voir}}
-   \ifcsdef{\website}{}{\def\@website{https://zestedesavoir.com}}
-   \ifcsdef{\editor}{}{\def\@editor{Zeste de Savoir}}   
+    \ifcsdef{@authorlink}{}{\authorlink{https://zestedesavoir.com/membres/voir}}
+    \ifcsdef{@website}{}{\website{https://zestedesavoir.com}}
+    \ifcsdef{@editor}{}{\editor{Zeste de Savoir}}   
     {\centering
     \vspace*{0.5 cm}
     \ifcsdef{@logo}{\includegraphics[width=\linewidth]{\@logo}}{$ $}\\[1.0 cm]
-    \LARGE \renewcommand*{\do}[1]{\href{\ifcsdef{\authorlink}{\@authorlink/##1/}{\bsc{##1}} \qquad}
+    \LARGE \renewcommand*{\do}[1]{\href{\@authorlink/##1/}{\bsc{##1}} \qquad}
            \expandafter\docsvlist\expandafter{\@author}\\[2.0 cm]
     \Large \href{\@website}{\@editor}\\[0.5 cm] 
     \rule{\linewidth}{0.2 mm} \\[0.4 cm]

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -130,7 +130,7 @@
 \newcommand{\authorlink}[1]{\def\@authorlink{#1}}
 
 \renewcommand{\maketitle}{%
-   \ifcsdef{\authorlink}{}{\def\@logo{https://zestedesavoir.com/membres/voir}}
+   \ifcsdef{\authorlink}{}{\def\@authorlink{https://zestedesavoir.com/membres/voir}}
    \ifcsdef{\website}{}{\def\@website{https://zestedesavoir.com}}
    \ifcsdef{\editor}{}{\def\@editor{Zeste de Savoir}}   
     {\centering

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -96,7 +96,7 @@
 %%%
 
 
-%%% ZDS BOX 
+%%% ZDS BOX
 
 \newcommand{\newZdSbox}[3]{{
 \theoremprework{~\\ \textcolor{#3}{\rule{0.6\linewidth}{1pt}}}
@@ -125,18 +125,24 @@
 
 \newcommand{\licence}[1]{\def\@licence{#1}}
 \newcommand{\logo}[1]{\def\@logo{#1}}
-
+\newcommand{\website}[1]{\def\@website{#1}}
+\newcommand{\editor}[1]{\def\@editor{#1}}
+\newcommand{\authorlink}[1]{\def\@authorlink{#1}}
 
 \renewcommand{\maketitle}{%
+   \ifcsdef{\authorlink}{}{\def\@logo{https://zestedesavoir.com/membres/voir}}
+   \ifcsdef{\website}{}{\def\@website{https://zestedesavoir.com}}
+   \ifcsdef{\editor}{}{\def\@editor{Zeste de Savoir}}   
     {\centering
     \vspace*{0.5 cm}
     \ifcsdef{@logo}{\includegraphics[width=\linewidth]{\@logo}}{$ $}\\[1.0 cm]
-    \LARGE \href{https://zestedesavoir.com/membres/voir/\@author/}{\bsc{\@author}}\\[2.0 cm]
-    \Large \href{https://zestedesavoir.com}{Zeste de Savoir}\\[0.5 cm] 
+    \LARGE \renewcommand*{\do}[1]{\href{\ifcsdef{\authorlink}{\@authorlink/##1/}{\bsc{##1}} \qquad}
+           \expandafter\docsvlist\expandafter{\@author}\\[2.0 cm]
+    \Large \href{\@website}{\@editor}\\[0.5 cm] 
     \rule{\linewidth}{0.2 mm} \\[0.4 cm]
     \huge\textbf{\@title}\\
-    \rule{\linewidth}{0.2 mm} \\[1.5 cm]  
-   \large\textbf{Ce tutoriel est sous licence \@licence}\\[2 cm]}
+    \rule{\linewidth}{0.2 mm} \\[1.5 cm]
+    \large\textbf{Ce tutoriel est sous licence \@licence}\\[2 cm]}
 }
 
 \hypersetup{pdftitle={\@title}}
@@ -145,6 +151,6 @@
 %%%
 
 \setlength{\tabcolsep}{0.2cm}
-\renewcommand{\arraystretch}{1.5}                                    
+\renewcommand{\arraystretch}{1.5}
 
-\newcommand{\horizontalLine}{{\color{gray}\rule{\textwidth}{0.2pt}}} 
+\newcommand{\horizontalLine}{{\color{gray}\rule{\textwidth}{0.2pt}}}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -132,13 +132,14 @@
 \renewcommand{\maketitle}{%
     \ifcsdef{@authorlink}{}{\authorlink{https://zestedesavoir.com/membres/voir}}
     \ifcsdef{@website}{}{\website{https://zestedesavoir.com}}
-    \ifcsdef{@editor}{}{\editor{Zeste de Savoir}}   
+    \ifcsdef{@editor}{}{\editor{Zeste de Savoir}}
+    \ifcsdef{@logo}{}{\logo{default_logo.png}}
     {\centering
     \vspace*{0.5 cm}
-    \ifcsdef{@logo}{\includegraphics[width=\linewidth]{\@logo}}{$ $}\\[1.0 cm]
+    \includegraphics[width=\linewidth]{\@logo}\\[1.0 cm]
     \LARGE \renewcommand*{\do}[1]{\href{\@authorlink/##1/}{\bsc{##1}} \qquad}
            \expandafter\docsvlist\expandafter{\@author}\\[2.0 cm]
-    \Large \href{\@website}{\@editor}\\[0.5 cm] 
+    \Large \href{\@website}{\@editor}\\[0.5 cm]
     \rule{\linewidth}{0.2 mm} \\[0.4 cm]
     \huge\textbf{\@title}\\
     \rule{\linewidth}{0.2 mm} \\[1.5 cm]


### PR DESCRIPTION
This PR fix #8. If `\website`, `\authorlink` or `\editor` are not used, the value for Zeste de Savoir are used. I can do the same for `\logo`, only need an image of by default (maybe Clem).