### PR TITLE
Add default value for smileys path

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -67,15 +67,13 @@ There is two way to include image.
 + With `\image{path}[caption]`, the image is centered and can have a caption.
 + With `\inlineImage{path}`, the image is in the text, not centered.
 
-## Smilies
+## Smileys
 
-Smilies need one commands to work (which should be defined in the preamble of the document):
+To obtain a smileys, use `\smiley{xxx}` where `xxx` is an in the directory containing smilies. By default, this directory is `./smileys`. It could be changed using `\smileysPath` macros in the preamble of the document.
 
 ```latex
-\smiliesPath{/path/to/smilies} % path to the directory containing the images of the smilies
+\smileysPath{/path/to/smileys} % path to the directory containing the images of the smilies
 ```
-
-Then, use `\smiley`: `\smiley{xxx}` where `xxx` is an image in the directory containing smilies.
 
 ## Spoilers
 

--- a/test.tex
+++ b/test.tex
@@ -6,7 +6,7 @@
 \author{Karnaj, Clem}
 \licence{CC-BY-NC-ND}
 
-\smiliesPath{./test-smilies}
+\smileysPath{./test-smilies}
 \makeglossaries
 
 \begin{document}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -305,8 +305,9 @@
 
 
 %% smilies
-\newcommand{\smiliesPath}[1]{\def\@smiliesPath{#1}}
-\newcommand{\smiley}[1]{\raisebox{-3pt}{\includegraphics[height=15pt]{\@smiliesPath/#1}} }
+\def\@smileysPath{./smileys}
+\newcommand{\smileysPath}[1]{\def\@smileysPath{#1}}
+\newcommand{\smiley}[1]{\raisebox{-3pt}{\includegraphics[height=15pt]{\@smileysPath/#1}} }
 
 %%%
 


### PR DESCRIPTION
Fix #48. I also use "smileys" instead of "smilies".