### PR TITLE
Add line numbers 

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -102,10 +102,10 @@ The `Quotation` environment takes an extra parameter, being the source of the qu
 
 ## Code environment
 
-To add a block of code, use the `codeBlock` environment. It takes in parameter the language which should be used (`text` for no language) and two extra parameter (the caption and numbers of lines which should be colored).
+To add a block of code, use the `codeBlock` environment. It takes in parameter the language which should be used (`text` for no language) and three extra parameter (the caption, the numbers of lines which should be colored, and the number of the first line).
 
 ```latex
-\begin{codeBlock}[eventual caption][1, 3, 4-7]{latex}
+\begin{codeBlock}[eventual caption][5, 8, 9-12][5]{latex}
 A \LaTeX command.   
 \end{codeBlock}
 ```

--- a/test.tex
+++ b/test.tex
@@ -108,7 +108,7 @@ def foo(bar):
 \begin{codeBlock}[][12][10]{python}
 def foo(bar): 
     if True:
-        return 42 # Cette ligne est en évidence et est numérotée 12
+        return 42 # This line is emphasized and is numbered 12.
     return 0
 \end{codeBlock}
 

--- a/test.tex
+++ b/test.tex
@@ -105,6 +105,12 @@ def foo(bar):
     return 0
 \end{codeBlock}
 
+\begin{codeBlock}[][12][10]{python}
+def foo(bar): 
+    if True:
+        return 42 # Cette ligne est en évidence et est numérotée 12
+    return 0
+\end{codeBlock}
 
 Une image hors-texte :
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -187,14 +187,14 @@
 \newZdSBoxEnvironement{Spoiler}{SpoilerBox}
 
 %%% CODE MANAGEMENT
-\setminted{breaklines, breaksymbolleft=\hspace{2em}, highlightcolor=highlightCodeColor} 
+\setminted{breaklines, breaksymbolleft=\hspace{2em}, highlightcolor=highlightCodeColor, linenos} 
 
-\NewDocumentEnvironment{codeBlock}{O{}O{}m}{%
+\NewDocumentEnvironment{codeBlock}{O{}O{}O{1}m}{%
    \def\@codeCaption{#1}
    \VerbatimEnvironment
    \FrameSep0.5em
    \begin{framed}\vspace{-1em}
-   \begin{minted}[highlightlines={#2}]{#3}%
+   \begin{minted}[highlightlines={#2}, firstnumber=#3]{#4}%
 }{
    \end{minted}\vspace{-0.5em}
    \end{framed}


### PR DESCRIPTION
With this PR, the lines are numbered. We can choose the number of the first line with the third optional argument of `codeBlock` environment.

```latex
\begin{codeBlock}[][10, 13][10]{python}
def test(truc):      # Cette ligne est en évidence et est numérotée 10
    print truc         # Cette ligne est numéroté 11
                         # Cette ligne est numéroté 12
test("coucou")     # Cette ligne est en évidence et est numérotée 13
\end{codeBlock}
```