### PR TITLE
Correct spoilers and code blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ test-images:
 	pdflatex -shell-escape -interaction=nonstopmode test-with-images.tex
 
 clean:
-	rm -f *.aux *.log *.out *.pdf *.thm *.toc *.glg *.glo *.gls *.glsdefs *.ist
-	rm -rf _minted-test
+	rm -f *.aux *.log *.out *.pdf *.thm *.toc *.glg *.glo *.gls *.glsdefs *.ist *.gz
+	rm -rf _minted-*
 	rm -f test-images/*converted-to*

--- a/documentation.md
+++ b/documentation.md
@@ -8,7 +8,7 @@
 + Superscript and subscript: `\textsubscript{x}` and `\textsuperscript{x}`
 + Inline source code: please use `\texttt{xxx}` rather than `\verb` if possible (see [this post on Stack Exchange](https://tex.stackexchange.com/a/10375)). Special characters (`\ $ & % # ^_ { } ~`) should therefore be escaped.
 + Keys: `\keys{x}`
-+ Footnotes: `\footnote{text}`
++ Footnotes: when defining a footnote, `\footnotetext[num]{\label{x} text}` (where `num` is the number of the footnote), when using the footnote, `\textsuperscript{\ref{x}}`.
 + Maths (obviously)
 
 ## Environments
@@ -80,10 +80,6 @@ To obtain a smiley, use `\smiley{xxx}` where `xxx` is a file from the smileys di
 \smileysPath{/path/to/smileys} % path to the directory containing the images of the smileys
 ```
 
-## Spoilers
-
-To add a spoiler, use `\addSpoiler`: `\addSpoiler{Hide text}`. Spoilers will be grouped in order of apparition in a "Spoiler" section at the end of each chapter.
-
 ## Iframes
 
 To add an iframe block (for example Youtube videos), use `\iframe`: `\iframe{url}[iframe type][caption]`.
@@ -100,16 +96,20 @@ Mimic the corresponding markdown blocks.
 
 The `Quotation` environment takes the the source of a quote as extra parameter.
 
+## Spoilers
+
+To add a spoiler, use the `Spoiler` environement. Spoilers will be grouped in order of apparition in a "Spoiler" section at the end of each chapter.
+
 ## Code environment
 
-To add a block of code, use the `codeBlock` environment. Its parameter is the language which should be used for syntax highlighting (`text` by default), it also accepts three extra parameter:
+To add a block of code, use the `CodeBlock` environment. Its parameter is the language which should be used for syntax highlighting (`text` by default), it also accepts three extra parameter:
 
 1. a legend/caption,
 2. the line numbers/range to be highlighted,
 3. the starting line number.
 
 ```latex
-\begin{codeBlock}[optional caption][5, 8, 9-12][5]{latex}
+\begin{CodeBlock}[optional caption][5, 8, 9-12][5]{latex}
 A \LaTeX command.
-\end{codeBlock}
+\end{CodeBlock}
 ```

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox pdfbase"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox pdfbase"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/test.tex
+++ b/test.tex
@@ -17,15 +17,21 @@
 
 Ce message s’adresse principalement aux bon connaisseurs de LaTeX : l’équipe de développement a besoin de vous ! \smiley{clin}
 
-\addSpoiler{Voici un secret.}
+\begin{Spoiler}
+Voici un secret
+\end{Spoiler}
 
 \levelOneTitle{Contexte}
 
-Nous travaillons actuellement sur la refonte de l’outils qui gère la partie \abbr{MD}{Markdown} -> autres formats et nous souhaitons refaire le template actuel LaTeX. Nous utilisons celui de base de Pandoc or cet outil sera remplacé dans le futur. Nous cherchons donc quelques personnes pour nous aider dans la réalisation de macros pour chaque élément spécifique à ZdS.
+Nous travaillons actuellement sur la refonte de l’outils qui gère la partie \abbr{MD}{Markdown} -> autres formats et nous souhaitons refaire le template actuel LaTeX\textsuperscript{\ref{pandoc}}. Nous utilisons celui de base de Pandoc\textsuperscript{\ref{pandoc}} or cet outil sera remplacé dans le futur. Nous cherchons donc quelques personnes pour nous aider dans la réalisation de macros pour chaque élément spécifique à ZdS.
+
+\footnotetext[1]{\label{pandoc} Parce que Pandoc, c'est un peu l'horreur}
 
 Si vous avez des questions et/ou si vous êtes intéressés, n’hésitez pas à passer sur IRC ou à laisser un message par ici \smiley{diable}
 
-\addSpoiler{Voici un autre secret.}
+\begin{Spoiler}
+Voici un autre secret.
+\end{Spoiler}
 
 \levelTwoTitle{Les éléments à faire}
 \levelThreeTitle{Ensemble des éléments classiques}
@@ -39,7 +45,9 @@ Si vous avez des questions et/ou si vous êtes intéressés, n’hésitez pas à
 \item \externalLink{liens}{zestedesavoir.com}
 \end{itemize}
 
-\addSpoiler{Un dernier petit secret.}
+\begin{Spoiler}
+Voici un dernier secret.
+\end{Spoiler}
 
 \begin{flushleft}
 Texte aligné à gauche
@@ -77,40 +85,40 @@ La suite, avec des touches \keys{CTRL} + \keys{A}. Et on peut avoir une ligne av
 
 Voici un peu de code inline: \verb`make test`. Et voici quelques exemples de code python :
 
-\begin{codeBlock}{python}
+\begin{CodeBlock}{python}
 def foo(bar):
     if True:
         return 42
     return 0
-\end{codeBlock}
+\end{CodeBlock}
 
-\begin{codeBlock}[Code légendé]{python}
+\begin{CodeBlock}[Code légendé]{python}
 def foo(bar):
     if True:
         return 42
     return 0
-\end{codeBlock}
+\end{CodeBlock}
 
-\begin{codeBlock}[Code légendé avec lignes colorés][1-2]{python}
+\begin{CodeBlock}[Code légendé avec lignes colorés][1-2]{python}
 def foo(bar):
     if True:
         return 42
     return 0
-\end{codeBlock}
+\end{CodeBlock}
 
-\begin{codeBlock}[][1, 3-4]{python}
+\begin{CodeBlock}[][1, 3-4]{python}
 def foo(bar):
     if True:
         return 42
     return 0
-\end{codeBlock}
+\end{CodeBlock}
 
-\begin{codeBlock}[][12][10]{python}
+\begin{CodeBlock}[][12][10]{python}
 def foo(bar):
     if True:
         return 42 # This line is emphasized and is numbered 12.
     return 0
-\end{codeBlock}
+\end{CodeBlock}
 
 Une image hors-texte :
 
@@ -179,7 +187,15 @@ element & element & element\\ \hline
 
 \levelOneConclusion
 
-\addSpoiler{On va quand même mettre un secret pour finir.}
+\begin{Spoiler}
+Et un secret ici pour finir en beauté, avec du code dans le dedans !
+
+\begin{CodeBlock}[][1]{python}
+def test(a):
+    print(a)
+\end{CodeBlock}
+\end{Spoiler}
 
 Conclusion
+
 \end{document}

--- a/test.tex
+++ b/test.tex
@@ -194,6 +194,31 @@ Et un secret ici pour finir en beauté, avec du code dans le dedans !
 def test(a):
     print(a)
 \end{CodeBlock}
+
+Et une image:
+
+\begin{center}
+\includegraphics[width=\linewidth]{logo.png}
+\captionof{figure}{Légende}
+\end{center}
+
+Et un tableau:
+
+\begin{longtabu}{|c|c|c|} \hline
+element & element & element\\ \hline
+element & element & element\\ \hline
+element & element & element\\ \hline
+element & element & element\\ \hline
+element & element & element\\ \hline
+\caption{Légende du tableau}
+\end{longtabu}
+
+Et une citation:
+
+\begin{Quotation}[me]
+\textit{What a pain in the ass!}
+\end{Quotation}
+
 \end{Spoiler}
 
 Conclusion

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -239,9 +239,9 @@
 
 \newenvironment{Spoiler}{%
    \addtocounter{@spoilerCounter}{1}%
-   \begin{xlrbox}{spoilerSavebox\the@spoilerCounter}\begin{minipage}{\linewidth}%
+   \begin{xlrbox}{spoilerSavebox\the@spoilerCounter}\begin{minipage}{\linewidth}\begin{NoHyper}%
 }{
-   \vspace*{1em}\end{minipage}\end{xlrbox}%
+   \vspace*{1em}\end{NoHyper}\end{minipage}\end{xlrbox}%
    \hypertarget{voir:\thepart\thechapter\the@spoilerCounter}{}
    \begin{SpoilerEnv}
       \hyperlink{secret:\thepart\thechapter\the@spoilerCounter}{Voir le secret \the@spoilerCounter.}
@@ -254,8 +254,8 @@
    \ifdefvoid{\@spoilerList}{}{\levelSpoilerTitle{Blocs secrets}}
    \def\do{}
    \renewcommand{\do}[1]{%
+      \levelSpoiler*{Secret \the@spoilerCounter}%
       \hypertarget{secret:\thepart\thechapter\the@spoilerCounter}{}
-      \levelSpoiler*{Secret \the@spoilerCounter}
       \expandafter{##1}\\ \hfill \hyperlink{voir:\thepart\thechapter\the@spoilerCounter}{Retourner au texte.}
       \addtocounter{@spoilerCounter}{1}
    }

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -20,6 +20,7 @@
 %% LATEX 3 PACKAGES
 \RequirePackage{etoolbox}
 \RequirePackage{xparse}
+\RequirePackage{xsavebox}
 
 \RequirePackage{multicol}
 \RequirePackage{pagecolor}
@@ -191,12 +192,12 @@
 \newZdSBoxEnvironment{Question}{QuestionBox}
 \newZdSBoxEnvironment{Information}{InformationBox}
 \newZdSBoxEnvironment{Error}{ErrorBox}
-\newZdSBoxEnvironment{Spoiler}{SpoilerBox}
+\newZdSBoxEnvironment{SpoilerEnv}{SpoilerBox}
 
 %%% CODE MANAGEMENT
-\setminted{breaklines, breaksymbolleft=\hspace{2em}, highlightcolor=highlightCodeColor, linenos}
+\setminted{breaklines, breaksymbolleft=\hspace{2em}, highlightcolor=highlightCodeColor, linenos, fontsize=\small,baselinestretch=1}
 
-\NewDocumentEnvironment{codeBlock}{O{}O{}O{1}m}{%
+\NewDocumentEnvironment{CodeBlock}{O{}O{}O{1}m}{%
    \def\@codeCaption{#1}
    \VerbatimEnvironment
    \FrameSep0.5em
@@ -236,13 +237,16 @@
 \newcounter{@spoilerCounter}
 \def\@spoilerList{}
 
-\newcommand{\addSpoiler}[1]{%
-   \addtocounter{@spoilerCounter}{1}
+\newenvironment{Spoiler}{%
+   \addtocounter{@spoilerCounter}{1}%
+   \begin{xlrbox}{spoilerSavebox\the@spoilerCounter}\begin{minipage}{\linewidth}%
+}{
+   \vspace*{1em}\end{minipage}\end{xlrbox}%
    \hypertarget{voir:\thepart\thechapter\the@spoilerCounter}{}
-   \begin{Spoiler}
+   \begin{SpoilerEnv}
       \hyperlink{secret:\thepart\thechapter\the@spoilerCounter}{Voir le secret \the@spoilerCounter.}
-   \end{Spoiler}
-   \listadd{\@spoilerList}{\expandafter#1}
+   \end{SpoilerEnv}
+   \listgadd{\@spoilerList}{\xusebox{spoilerSavebox\the@spoilerCounter}}
 }
 
 \newcommand{\displaySpoilers}{%


### PR DESCRIPTION
That one wasn't easy, but I manage to do it. Now we can add code blocks in spoilers.

See [this documentation of the list functions](http://www.dickimaw-books.com/latex/admin/html/etoolboxlist.shtml) and the [xsavebox documentation](http://tug.ctan.org/macros/latex/contrib/xsavebox/xsavebox.pdf).

Changes:

+ `\addSpoiler{}` → `\begin{Spoiler}`
+ `\begin{codeBlock}`→ `\begin{CodeBlock}` (because if we have defined rules, is to follow them ^^)