### PR TITLE
enhancement/toc: Don't generate empty toc (fix #57)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ install:
 script:
     - make test
     - make test-images
+    - make test-without-toc

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,14 @@ test-images:
 	makeglossaries test-with-images
 	lualatex -shell-escape -interaction=nonstopmode test-with-images.tex
 
+test-without-toc:
+	lualatex -draftmode -shell-escape -interaction=nonstopmode test-without-toc.tex
+	lualatex -draftmode -shell-escape -interaction=nonstopmode test-without-toc.tex
+	makeglossaries test-without-toc
+	lualatex -shell-escape -interaction=nonstopmode test-without-toc.tex
+
 clean:
 	rm -f *.aux *.log *.out *.pdf *.thm *.toc *.glg *.glo *.gls *.glsdefs *.ist *.gz
 	rm -rf _minted-*
 	rm -f test-images/*converted-to*
+	rm -f *.data

--- a/documentation.md
+++ b/documentation.md
@@ -22,6 +22,8 @@
 
 # Class macros
 
+*__NOTE: Use `\toc` command for generating table of contents intsead of `\tableofcontents`__*
+
 ## Abbreviations
 
 To add an abbreviation, use `\abbr{word}{definition}`. Abbreviations will be listed in a glossary at the end of the document.
@@ -112,6 +114,10 @@ The `Quotation` environment takes the the source of a quote as extra parameter.
 ## Spoilers
 
 To add a spoiler, use the `Spoiler` environement. Spoilers will be grouped in order of apparition in a "Spoiler" section at the end of each chapter.
+
+## Table of contents
+
+For creation of table of contents, use `\toc`. This command doesn't generate table of contents if it is empty.
 
 ## Code environment
 

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg luacode"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/test-with-images.tex
+++ b/test-with-images.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\tableofcontents
+\toc
 
 \levelOneIntroduction
 

--- a/test-without-toc.tex
+++ b/test-without-toc.tex
@@ -1,0 +1,19 @@
+\documentclass[small]{zmdocument}
+
+\usepackage{blindtext}
+\usepackage{luacode}
+
+\title{Ceci est un titre}
+\author{Karnaj, Clem}
+\licence[./img/license/cc-by-nc-nd_icon.svg]{CC-BY-NC-ND}{https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode}
+
+\smileysPath{./test-smilies}
+\makeglossaries
+
+\begin{document}
+   \maketitle
+   \toc
+
+   foo \\
+
+\end{document}

--- a/test.tex
+++ b/test.tex
@@ -13,7 +13,7 @@
 
 \begin{document}
 \maketitle
-\tableofcontents
+\toc
 
 \levelOneIntroduction
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -19,6 +19,7 @@
 \RequirePackage{newfloat}
 \RequirePackage{ifthen}
 \RequirePackage{xifthen}
+\RequirePackage{luacode}
 
 %% LATEX 3 PACKAGES
 \RequirePackage{etoolbox}
@@ -172,16 +173,18 @@
 }
 
 %%% SECTIONNING OPTIONS
+\newcounter{@tocCounter}
+\setcounter{@tocCounter}{0}
 \lohead{\headmark}
 \chead{}
 \pagestyle{scrheadings}
 
 \DeclareOption{small}{
-   \let\levelOneTitle\section
-   \let\levelTwoTitle\subsection
-   \let\levelThreeTitle\subsubsection
-   \let\levelFourTitle\paragraph
-   \let\levelFiveTitle\subparagraph
+   \newcommand{\levelOneTitle}[1]{\stepcounter{@tocCounter}\section{#1}}
+   \newcommand{\levelTwoTitle}[1]{\stepcounter{@tocCounter}\subsection{#1}}
+   \newcommand{\levelThreeTitle}[1]{\stepcounter{@tocCounter}\subsubsection{#1}}
+   \newcommand{\levelFourTitle}[1]{\stepcounter{@tocCounter}\paragraph{#1}}
+   \newcommand{\levelFiveTitle}[1]{\stepcounter{@tocCounter}\subparagraph{#1}}
    \newcommand{\levelOneIntroduction}{\addsec{Introduction}}
    \newcommand{\levelOneConclusion}{\addsec{Conclusion}}
    \def\thesection{\arabic{section}}
@@ -192,12 +195,12 @@
 }
 
 \DeclareOption{middle}{
-   \newcommand{\levelOneTitle}[1]{\displaySpoilers \chapter{#1}}
-   \let\levelTwoTitle\section
-   \let\levelThreeTitle\subsection
-   \let\levelFourTitle\subsubsection
-   \let\levelFiveTitle\paragraph
-   \let\levelSixTitle\subparagaph
+   \newcommand{\levelOneTitle}[1]{\stepcounter{@tocCounter}\displaySpoilers \chapter{#1}}
+   \newcommand{\levelTwoTitle}[1]{\stepcounter{@tocCounter}\section{#1}}
+   \newcommand{\levelThreeTitle}[1]{\stepcounter{@tocCounter}\subsection{#1}}
+   \newcommand{\levelFourTitle}[1]{\stepcounter{@tocCounter}\subsubsection{#1}}
+   \newcommand{\levelFiveTitle}[1]{\stepcounter{@tocCounter}\paragraph{#1}}
+   \newcommand{\levelSixTitle}[1]{\stepcounter{@tocCounter}\subparagaph{#1}}
    \newcommand{\levelOneIntroduction}{\addchap{Introduction}}
    \newcommand{\levelOneConclusion}{\displaySpoilers \addchap{Conclusion}}
    \newcommand{\levelTwoIntroduction}{\addsec{Introduction}}
@@ -206,13 +209,13 @@
 }
 
 \DeclareOption{big}{
-   \newcommand\levelOneTitle[1]{\displaySpoilers \part{#1}}
-   \newcommand\levelTwoTitle[1]{\displaySpoilers \chapter{#1}}
-   \let\levelThreeTitle\section
-   \let\levelFourTitle\subsection
-   \let\levelFiveTitle\subsubsection
-   \let\levelSixTitle\paragraph
-   \let\levelSevenTitle\subparagaph
+   \newcommand{\levelOneTitle}[1]{\stepcounter{@tocCounter}\displaySpoilers \part{#1}}
+   \newcommand{\levelTwoTitle}[1]{\stepcounter{@tocCounter}\displaySpoilers \chapter{#1}}
+   \newcommand{\levelThreeTitle}[1]{\stepcounter{@tocCounter}\section{#1}}
+   \newcommand{\levelFourTitle}[1]{\stepcounter{@tocCounter}\subsection{#1}}
+   \newcommand{\levelFiveTitle}[1]{\stepcounter{@tocCounter}\subsubsection{#1}}
+   \newcommand{\levelSixTitle}[1]{\stepcounter{@tocCounter}\paragraph{#1}}
+   \newcommand{\levelSevenTitle}[1]{\stepcounter{@tocCounter}\subparagaph{#1}}
    \newcommand{\levelOneIntroduction}{\addpart{Introduction}}
    \newcommand{\levelOneConclusion}{\displaySpoilers \addpart{Conclusion}}
    \newcommand{\levelTwoIntroduction}{\addchap{Introduction}}
@@ -525,6 +528,37 @@
 
 \hypersetup{pdftitle={\@title}}
 \hypersetup{pdfauthor={\@author}}
+
+%%% TABLE OF CONTENTS
+
+\begin{luacode*}
+function setFileCompileName (jobname)
+   filename=jobname .. "-compile-toc.data"
+end
+
+function printToc ()
+   local f = io.open(filename,"r")
+   if f ~= nil then
+      local value=f:read "*n"
+      if value ~= 0 then
+         tex.print("\\tableofcontents\\newpage")
+      end
+      io.close(f)
+   end
+end
+\end{luacode*}
+
+\directlua{setFileCompileName("\jobname")}
+
+\newcommand{\toc}{\directlua{printToc()}}
+
+\AtEndDocument{
+   \directlua{
+      f=io.open(filename,"w")
+      f:write("\the@tocCounter")
+      f:close()
+   }
+}
 
 %%% IMAGES
 \NewDocumentCommand{\image}{mo}{%


### PR DESCRIPTION
When compiling, one file are created who contains number of element in
toc (because we only know it at the end of the first compilation), so
at the second he will read the file and find out if he should print
the toc.

*Note: need cash clean because I use new package*