### PR TITLE
Enhancement/fonts: Change font

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
 
 install:
   - mkdir -p $HOME/bin
+  - ./scripts/install_font.sh
   - ./scripts/install_texlive.sh
   - export PATH=$HOME/.texlive/bin/x86_64-linux:$PATH
   - pip install Pygments

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ pip install Pygments
 
 Note that this package requires latex to be called with the `-shell-escape` option.
 
+You also need these fonts:
+
+- [Source Code Pro](https://www.fontsquirrel.com/fonts/source-code-pro)
+- [Source Sans Pro](https://www.fontsquirrel.com/fonts/source-sans-pro)
+- [Merriweather](https://www.fontsquirrel.com/fonts/merriweather)
+
 ## Other images formats
 
 To be abble to use GIF and SVG images in your documents, two extra programs are needed:

--- a/scripts/install_font.sh
+++ b/scripts/install_font.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Configure font folder
+FONT_DIR="${HOME}/.local/share/fonts"
+mkdir -p ${FONT_DIR}
+cd ${FONT_DIR}
+
+function Download_Font {
+    if [ $# -eq 1 ]
+    then
+        mkdir ${1}
+        cd ${1}
+
+        wget -qO "${1}.zip" https://www.fontsquirrel.com/fonts/download/${1}
+        unzip ${1}.zip
+        rm -rf ${1}.zip
+
+        cd ..
+    fi
+}
+
+# Download Merriweather font
+
+Download_Font merriweather
+
+# Download Source Sans Pro
+
+Download_Font source-sans-pro
+
+# Download Source Code Pro
+
+Download_Font source-code-pro
+
+# Update cache
+fc-cache -frv

--- a/scripts/install_font.sh
+++ b/scripts/install_font.sh
@@ -4,20 +4,29 @@ set -e
 
 # Configure font folder
 FONT_DIR="${HOME}/.local/share/fonts"
+UPDATE_CACHE=false
+
 mkdir -p ${FONT_DIR}
 cd ${FONT_DIR}
 
 function Download_Font {
     if [ $# -eq 1 ]
     then
-        mkdir ${1}
-        cd ${1}
+        if [ ! -d "${1}" ]
+        then
+            UPDATE_CACHE=true
+            mkdir ${1}
+            cd ${1}
 
-        wget -qO "${1}.zip" https://www.fontsquirrel.com/fonts/download/${1}
-        unzip ${1}.zip
-        rm -rf ${1}.zip
+            wget -qO "${1}.zip" https://www.fontsquirrel.com/fonts/download/${1}
+            unzip ${1}.zip
+            rm -rf ${1}.zip
 
-        cd ..
+            cd ..
+
+        else
+            echo "Using cached font ${1}"
+        fi
     fi
 }
 
@@ -34,4 +43,9 @@ Download_Font source-sans-pro
 Download_Font source-code-pro
 
 # Update cache
-fc-cache -frv
+if [ $UPDATE_CACHE = true ]
+then
+    fc-cache -frv
+else
+    echo "Cache no need to be updated"
+fi

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -7,6 +7,7 @@
 
 \RequirePackage[utf8]{inputenc}
 \RequirePackage[T1]{fontenc}
+\RequirePackage{fontspec}
 \RequirePackage{scrhack}
 \RequirePackage[dvipsnames,table]{xcolor}
 \RequirePackage{scrlayer-scrpage}
@@ -54,6 +55,11 @@
 
 %%% ABBREVIATIONS PACKAGES
 \RequirePackage{glossaries}
+
+%%% FONTS
+\setmainfont{Merriweather}
+\setsansfont{Source Sans Pro}
+\setmonofont{Source Code Pro}
 
 %%% COLORS ---------------------------------------------------------------------
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -56,7 +56,6 @@
 \RequirePackage{glossaries}
 
 %%% FONTS
-\setmainfont{Merriweather}
 \setsansfont{Source Sans Pro}
 \setmonofont{Source Code Pro}
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -6,7 +6,6 @@
 %%% PACKAGES -------------------------------------------------------------------
 
 \RequirePackage[utf8]{inputenc}
-\RequirePackage[T1]{fontenc}
 \RequirePackage{fontspec}
 \RequirePackage{scrhack}
 \RequirePackage[dvipsnames,table]{xcolor}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -469,6 +469,7 @@
 }
 
 \renewcommand{\maketitle}{%
+   \setcounter{page}{0}
    \ifcsdef{@authorlink}{}{\authorlink{https://zestedesavoir.com/membres/voir}}
    \ifcsdef{@website}{}{\website{https://zestedesavoir.com}}
    \ifcsdef{@editor}{}{\editor{https://zestedesavoir.com}}


### PR DESCRIPTION
Use these fonts:

- Source Code Pro: mono
- Source Sans Pro: sans
- Merriweather: serif

And fix wrong return page of abbreviation

Example:
[test.pdf](https://github.com/zestedesavoir/latex-template/files/1431863/test.pdf)
