### PR TITLE
Fix: Fix unicode char in toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Here is a skeleton on what your LaTeX document should contain:
 
 \title{Title}
 \author{Author}
-\licence{CC-BY-NC-ND}
+\licence[path/to/image]{Licence name}{URL} % optional
 \logo{logo.png}  % if ./logo.png is available
 
 \begin{document}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -44,7 +44,7 @@
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{rsvg-convert -f pdf #1 -o \OutputFile}
 \AppendGraphicsExtensions{.svg}
 
-\RequirePackage[bookmarks=true,hyperindex=true,bookmarksopen=true,bookmarksnumbered=true]{hyperref}
+\RequirePackage[luatex,unicode,bookmarks=true,hyperindex=true,bookmarksopen=true,bookmarksnumbered=true]{hyperref}
 \RequirePackage[thmmarks,amsmath,hyperref]{ntheorem}
 \RequirePackage[hyperrefcolorlinks]{menukeys}
 


### PR DESCRIPTION
Related in [hyperref and loading accents](https://tex.stackexchange.com/questions/257051/hyperref-and-loading-accents/257052#257052) topic, add unicode flag in hyperref option for unicode support.