### PR TITLE
Fix/author: Cover author issue (fix #68) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.thm
 *.toc
 *.xdy
+*.listing
 _minted*
 *converted-to*
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.toc
 *.xdy
 *.listing
+.idea
 _minted*
 *converted-to*
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "utf8.lua"]
+	path = utf8.lua
+	url = https://github.com/Stepets/utf8.lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ install:
 script:
     - make test
     - make test-images
+    - make test-author

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,6 @@ test-images:
 	lualatex -shell-escape -interaction=nonstopmode test-with-images.tex
 
 clean:
-	rm -f *.aux *.log *.out *.pdf *.thm *.toc *.glg *.glo *.gls *.glsdefs *.ist *.gz
+	rm -f *.aux *.log *.out *.pdf *.thm *.toc *.glg *.glo *.gls *.glsdefs *.ist *.gz *.listing
 	rm -rf _minted-*
 	rm -f test-images/*converted-to*

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ test:
 	makeglossaries test
 	lualatex -shell-escape -interaction=nonstopmode test.tex
 
+test-author:
+	lualatex -draftmode -shell-escape -interaction=nonstopmode test-author.tex
+	lualatex -draftmode -shell-escape -interaction=nonstopmode test-author.tex
+	makeglossaries test-author
+	lualatex -shell-escape -interaction=nonstopmode test-author.tex
+
 test-images:
 	lualatex -draftmode -shell-escape -interaction=nonstopmode test-with-images.tex
 	lualatex -draftmode -shell-escape -interaction=nonstopmode test-with-images.tex

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You need a standard (full) LaTeX distribution:
 
 Since this template uses the [minted](https://github.com/gpoore/minted/) package you also need [Pygments](http://pygments.org/), probably available in your package manager on Linux or via `pip`:
 
+This repo uses submodules. After clone this repo, in root folder of the project, execute this command to download submodule: `git submodule update --init --recursive`
+
 ```bash
 pip install Pygments
 ```

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec luacode"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec luacode ctablestack"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec luacode ctablestack"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec luacode"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -3,7 +3,7 @@
 # Forked from Zeste de Savoir:
 # https://github.com/zestedesavoir/zds-site/blob/a16c5fc932b361cbee5c6e61b24167605e24cd8b/scripts/install_texlive.sh
 
-EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec"
+EXTRA_PACKAGES="adjustbox blindtext capt-of catoptions cm-super collectbox framed fvextra glossaries ifplatform menukeys minted multirow ntheorem pagecolor relsize tabu varwidth xpatch xstring mfirstuc xfor datatool substr tracklang xsavebox media9 tcolorbox environ etoolbox trimspaces ifthen geometry xifthen ifmtarg fontspec luacode"
 
 if [[ -f $HOME/.texlive/bin/x86_64-linux/tlmgr ]]; then
   echo "Using cached texlive install"

--- a/test-author.tex
+++ b/test-author.tex
@@ -1,0 +1,23 @@
+\documentclass[small]{zmdocument}
+
+\usepackage{blindtext}
+
+\title{Ceci est un titre}
+\author{SpaceFox, elyppire, adri1, Fumble, viki53, tcit, Taurre, Algue-Rythme, informaticienzero, Aabu, Roipoussiere, Glordim, Holosmos, Saroupille, Gabbrovictor, artragis, Sandhose, gcodeur, ache}
+\licence[./img/license/cc-by-nc-nd_icon.svg]{CC-BY-NC-ND}{https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode}
+
+\editorLogo[La connaissance pour tous et sans pépins]{./img/logo/zestedesavoir.svg}
+
+\smileysPath{./test-smileys}
+\makeglossaries
+
+\begin{document}
+\maketitle
+\tableofcontents
+\newpage
+
+\levelOneIntroduction
+
+Ce message s’adresse principalement aux bon connaisseurs de LaTeX : l’équipe de développement a besoin de vous ! \smiley{clin}
+
+\end{document}

--- a/test.tex
+++ b/test.tex
@@ -14,6 +14,7 @@
 \begin{document}
 \maketitle
 \tableofcontents
+\newpage
 
 \levelOneIntroduction
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -516,7 +516,7 @@
    \newpage
    \setcounter{page}{1}
    % Author page (if necessary)
-   \directlua{makeAuthorsPage(\luastringO{\@authorlink})}
+   \directlua{makeAuthorsPage()}
    \newpage
 }
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -18,6 +18,7 @@
 \RequirePackage{newfloat}
 \RequirePackage{ifthen}
 \RequirePackage{xifthen}
+\usepackage{luacode}
 
 %% LATEX 3 PACKAGES
 \RequirePackage{etoolbox}
@@ -57,6 +58,9 @@
 %%% FONTS
 \setsansfont{Source Sans Pro}
 \setmonofont{Source Code Pro}
+
+%%% Lua scripts
+\directlua{dofile("zmdocument.lua")}
 
 %%% COLORS ---------------------------------------------------------------------
 
@@ -447,26 +451,6 @@
    \expandafter\docsvlist\expandafter{#1}
 }
 
-\newcommand{\formatAuthors}{%
-   \setlength{\columnsep}{0pt}
-   \newcounter{@authorsNumber}
-   \newcounter{@authorsByColumn}
-   \newcounter{@columnNumber}
-   \setcounter{@authorsByColumn}{5}
-   \getListSize{\@author}
-   \setcounter{@authorsNumber}{\the@listSize}
-   \setcounter{@columnNumber}{\the\numexpr(1 + \the@authorsNumber / \the@authorsByColumn)\relax}
-   \thispagestyle{empty}
-   \Large \bfseries \renewcommand*{\do}[1]{\href{\@authorlink/##1/}{\color{titlePageAuthorColor}\bsc{##1}}\\}
-   \ifnum\the@authorsNumber < \the\numexpr(1+\the@authorsByColumn)
-      \expandafter\docsvlist\expandafter{\@author}
-   \else
-      \begin{multicols}{\the@columnNumber}
-         \expandafter\docsvlist\expandafter{\@author}
-      \end{multicols}
-   \fi
-}
-
 \renewcommand{\maketitle}{%
    \setcounter{page}{0}
    \ifcsdef{@authorlink}{}{\authorlink{https://zestedesavoir.com/membres/voir}}
@@ -484,7 +468,7 @@
          \begin{tabular}{ p{0.7\textwidth} p{0.3\textwidth}  }
             \vspace{0pt}
             \begin{minipage}{0.7\textwidth}
-               \formatAuthors
+               \directlua{formatAuthors(\luastringO{\@author}, \luastringO{\@authorlink})}
             \end{minipage}
                &
             \vspace{0pt}
@@ -526,7 +510,14 @@
    \newpage
    \newpagecolor{white}
    \color{black}
+   % flyleaf
+   \strut
+   \thispagestyle{empty}
+   \newpage
    \setcounter{page}{1}
+   % Author page (if necessary)
+   \directlua{makeAuthorsPage(\luastringO{\@authorlink})}
+   \newpage
 }
 
 \hypersetup{pdftitle={\@title}}

--- a/zmdocument.lua
+++ b/zmdocument.lua
@@ -1,4 +1,4 @@
-utf8 = require "utf8-lua/utf8.lua"
+utf8 = require "./utf8.lua/utf8.lua"
 
 AUTHOR_MAX_SIZE = 15
 AUTHOR_MAX_DISPLAY = 11

--- a/zmdocument.lua
+++ b/zmdocument.lua
@@ -1,11 +1,11 @@
 utf8 = require "./utf8.lua/utf8.lua"
 
-AUTHOR_MAX_SIZE = 15
+AUTHOR_MAX_SIZE    = 15
 AUTHOR_MAX_DISPLAY = 11
-
-array_authors = {}
-array_authors_size = 0
-numberOfColumns = 1
+AUTHOR_LINK        = ""
+ARRAY_AUTHORS      = {}
+ARRAY_AUTHORS_SIZE = 0
+NUMBER_OF_COLUMNS  = 1
 
 --  Split and Join a string into / from a table
 --  source: http://www.wellho.net/resources/ex.php4?item=u105/spjo
@@ -22,11 +22,11 @@ function implode (delimiter, list)
 end
 
 --  Create array of authors which contains for all author
---  - name : default name
---  - display_name : short name (less than AUTHOR_MAX_SIZE) that will be displayed
+--  - name: default name
+--  - display_name: short name (less than AUTHOR_MAX_SIZE) that will be displayed
 function makeAuthorsArray (authors)
-   array_authors = {}
-   local index = -1
+   ARRAY_AUTHORS = {}
+   local index   = -1
    local tmp_name
 
    for word in string.gmatch (authors, '([^,]+)') do
@@ -34,29 +34,29 @@ function makeAuthorsArray (authors)
 
       --  Trim
       tmp_name = string.format ("%s", word:match ("%s*(.+)%s*"))
-      array_authors[index] = { name = tmp_name, display_name = tmp_name }
+      ARRAY_AUTHORS[index] = { name = tmp_name, display_name = tmp_name }
 
       --  Count number of backslash in string to remove it from the count of the size
-      --  Note: this method no cover all backslash aspect (like command), it is just for simple char
+      --  Note: this method no cover all backslash aspect (like command), it is just for simple escaped char
       local numberOfBackslash = 0
-      for i in string.gmatch (array_authors[index].display_name, "\\") do
+      for i in string.gmatch (ARRAY_AUTHORS[index].display_name, "\\") do
          numberOfBackslash = numberOfBackslash + 1
       end
 
       --  Limit size of display name to AUTHOR_MAX_SIZE
-      if (utf8.len (array_authors[index].display_name) - numberOfBackslash) > AUTHOR_MAX_SIZE then
-         array_authors[index].display_name = string.sub (array_authors[index].display_name, 0, AUTHOR_MAX_SIZE - 3) .. "..."
+      if (utf8.len (ARRAY_AUTHORS[index].display_name) - numberOfBackslash) > AUTHOR_MAX_SIZE then
+         ARRAY_AUTHORS[index].display_name = string.sub (ARRAY_AUTHORS[index].display_name, 0, AUTHOR_MAX_SIZE - 3) .. "..."
       end
    end
 
-   array_authors_size = index
+   ARRAY_AUTHORS_SIZE = index
 end
 
 --  Display athors
 --  If "all" parameter is not nil, this will display all authors
-function displayAuthors (link, all)
-   all = all or false
-   local index = array_authors_size
+function displayAuthors (all)
+   all         = all or false
+   local index = ARRAY_AUTHORS_SIZE
 
    if index > AUTHOR_MAX_DISPLAY and not all then
       index = AUTHOR_MAX_DISPLAY
@@ -65,14 +65,14 @@ function displayAuthors (link, all)
    local tab = {}
 
    for i = 0, index do
-      tab[i] = "\\href{" .. link .. "/" .. array_authors[i].name .. "/}{\\color{titlePageAuthorColor}\\bsc{" .. array_authors[i].display_name .. "}}\\\\"
+      tab[i] = "\\href{" .. AUTHOR_LINK .. "/" .. ARRAY_AUTHORS[i].name .. "/}{\\color{titlePageAuthorColor}\\bsc{" .. ARRAY_AUTHORS[i].display_name .. "}}\\\\"
    end
 
    local strAuthors = implode (",", tab)
 
-   if array_authors_size > AUTHOR_MAX_DISPLAY and not all then
+   if ARRAY_AUTHORS_SIZE > AUTHOR_MAX_DISPLAY and not all then
       strAuthors = strAuthors .. ", \\hyperlink{authorsList}{\\color{titlePageAuthorColor}\\bsc{et " ..
-         (array_authors_size - AUTHOR_MAX_DISPLAY) .. " autre(s) auteur(s)}}\\\\"
+         (ARRAY_AUTHORS_SIZE - AUTHOR_MAX_DISPLAY) .. " autre(s) auteur(s)}}\\\\"
    end
 
    print (strAuthors)
@@ -82,47 +82,47 @@ end
 
 --  Return the number of authors can be displayed (lower or equal to AUTHOR_MAX_DISPLAY)
 function getAuthorsNumberMaxDisplayed ()
-   if array_authors_size > AUTHOR_MAX_DISPLAY then
+   if ARRAY_AUTHORS_SIZE > AUTHOR_MAX_DISPLAY then
       return AUTHOR_MAX_DISPLAY
    else
-      return array_authors_size
+      return ARRAY_AUTHORS_SIZE
    end
 end
 
 --  Format authors for displaying on cover
 function formatAuthors (authors, link)
    makeAuthorsArray (authors)
+   AUTHOR_LINK = link
    local authorsByColumn = 5
    local authorsNumber = getAuthorsNumberMaxDisplayed ()
 
-   numberOfColumns = math.ceil (authorsNumber / authorsByColumn)
+   NUMBER_OF_COLUMNS = math.ceil (authorsNumber / authorsByColumn)
 
-   if numberOfColumns > 1 then
-      tex.print ("\\begin{multicols}{" .. numberOfColumns .. "}")
+   if NUMBER_OF_COLUMNS > 1 then
+      tex.print ("\\begin{multicols}{" .. NUMBER_OF_COLUMNS .. "}")
    end
 
-   displayAuthors (link)
+   displayAuthors ()
 
-   if numberOfColumns > 1 then
+   if NUMBER_OF_COLUMNS > 1 then
       tex.print ("\\end{multicols}")
    end
 end
 
 --  Create page for display all authors, only if all authors are not displayed on cover
-function makeAuthorsPage (link)
-
-   if array_authors_size <= AUTHOR_MAX_DISPLAY then
+function makeAuthorsPage ()
+   if ARRAY_AUTHORS_SIZE <= AUTHOR_MAX_DISPLAY then
       --  Displaying this page only if all authors are not displayed on cover
       return
    end
 
-   if numberOfColumns > 1 then
-      tex.print ("\\begin{center}\\section*{\\hypertarget{authorsList}{Auteurs}}\\end{center}\\begin{multicols}{" .. numberOfColumns .. "}")
+   if NUMBER_OF_COLUMNS > 1 then
+      tex.print ("\\begin{center}\\section*{\\hypertarget{authorsList}{Auteurs}}\\end{center}\\begin{multicols}{" .. NUMBER_OF_COLUMNS .. "}")
    end
 
-   displayAuthors(link, true)
+   displayAuthors(true)
 
-   if numberOfColumns > 1 then
+   if NUMBER_OF_COLUMNS > 1 then
       tex.print ("\\end{multicols}\\newpage")
    end
 end

--- a/zmdocument.lua
+++ b/zmdocument.lua
@@ -1,0 +1,128 @@
+utf8 = require "utf8-lua/utf8.lua"
+
+AUTHOR_MAX_SIZE = 15
+AUTHOR_MAX_DISPLAY = 11
+
+array_authors = {}
+array_authors_size = 0
+numberOfColumns = 1
+
+--  Split and Join a string into / from a table
+--  source: http://www.wellho.net/resources/ex.php4?item=u105/spjo
+function implode (delimiter, list)
+   local len = #list
+   if len == 0 then
+      return ""
+   end
+   local string = list[0]
+   for i = 1, len do
+      string = string .. delimiter .. list[i]
+   end
+   return string
+end
+
+--  Create array of authors which contains for all author
+--  - name : default name
+--  - display_name : short name (less than AUTHOR_MAX_SIZE) that will be displayed
+function makeAuthorsArray (authors)
+   array_authors = {}
+   local index = -1
+   local tmp_name
+
+   for word in string.gmatch (authors, '([^,]+)') do
+      index = index + 1
+
+      --  Trim
+      tmp_name = string.format ("%s", word:match ("%s*(.+)%s*"))
+      array_authors[index] = { name = tmp_name, display_name = tmp_name }
+
+      --  Count number of backslash in string to remove it from the count of the size
+      --  Note: this method no cover all backslash aspect (like command), it is just for simple char
+      local numberOfBackslash = 0
+      for i in string.gmatch (array_authors[index].display_name, "\\") do
+         numberOfBackslash = numberOfBackslash + 1
+      end
+
+      --  Limit size of display name to AUTHOR_MAX_SIZE
+      if (utf8.len (array_authors[index].display_name) - numberOfBackslash) > AUTHOR_MAX_SIZE then
+         array_authors[index].display_name = string.sub (array_authors[index].display_name, 0, AUTHOR_MAX_SIZE - 3) .. "..."
+      end
+   end
+
+   array_authors_size = index
+end
+
+--  Display athors
+--  If "all" parameter is not nil, this will display all authors
+function displayAuthors (link, all)
+   all = all or false
+   local index = array_authors_size
+
+   if index > AUTHOR_MAX_DISPLAY and not all then
+      index = AUTHOR_MAX_DISPLAY
+   end
+
+   local tab = {}
+
+   for i = 0, index do
+      tab[i] = "\\href{" .. link .. "/" .. array_authors[i].name .. "/}{\\color{titlePageAuthorColor}\\bsc{" .. array_authors[i].display_name .. "}}\\\\"
+   end
+
+   local strAuthors = implode (",", tab)
+
+   if array_authors_size > AUTHOR_MAX_DISPLAY and not all then
+      strAuthors = strAuthors .. ", \\hyperlink{authorsList}{\\color{titlePageAuthorColor}\\bsc{et " ..
+         (array_authors_size - AUTHOR_MAX_DISPLAY) .. " autre(s) auteur(s)}}\\\\"
+   end
+
+   print (strAuthors)
+
+   tex.print ("\\expandafter\\docsvlist\\expandafter{" .. strAuthors .. "}")
+end
+
+--  Return the number of authors can be displayed (lower or equal to AUTHOR_MAX_DISPLAY)
+function getAuthorsNumberMaxDisplayed ()
+   if array_authors_size > AUTHOR_MAX_DISPLAY then
+      return AUTHOR_MAX_DISPLAY
+   else
+      return array_authors_size
+   end
+end
+
+--  Format authors for displaying on cover
+function formatAuthors (authors, link)
+   makeAuthorsArray (authors)
+   local authorsByColumn = 5
+   local authorsNumber = getAuthorsNumberMaxDisplayed ()
+
+   numberOfColumns = math.ceil (authorsNumber / authorsByColumn)
+
+   if numberOfColumns > 1 then
+      tex.print ("\\begin{multicols}{" .. numberOfColumns .. "}")
+   end
+
+   displayAuthors (link)
+
+   if numberOfColumns > 1 then
+      tex.print ("\\end{multicols}")
+   end
+end
+
+--  Create page for display all authors, only if all authors are not displayed on cover
+function makeAuthorsPage (link)
+
+   if array_authors_size <= AUTHOR_MAX_DISPLAY then
+      --  Displaying this page only if all authors are not displayed on cover
+      return
+   end
+
+   if numberOfColumns > 1 then
+      tex.print ("\\begin{center}\\section*{\\hypertarget{authorsList}{Auteurs}}\\end{center}\\begin{multicols}{" .. numberOfColumns .. "}")
+   end
+
+   displayAuthors(link, true)
+
+   if numberOfColumns > 1 then
+      tex.print ("\\end{multicols}\\newpage")
+   end
+end


### PR DESCRIPTION
This commit fix issue related to authors.
Display only 11 authors on cover and if there are more than,
it will display all authors on a new page between flyleaf and table of
contents.

This commit add:

- flyleaf: just after cover (blank page)
- Author page: diplay only if there is more than 11 authors

Note: lua script requiert [utf8.lua](https://github.com/Stepets/utf8.lua)

fix #68 