### PR TITLE
 fix/inline-code: Fix issue with inlineCode

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -43,11 +43,9 @@ Add licence with `\licence[path/to/image]{Licence name}{URL}`.
 
 ## Inline source code 
 
-Create a inline source code with `\CodeInline[bash]{make test}`.
+Create a inline source code with `\CodeInline{make test}`.
 
-*Note: special chars doesn't need to be escaped.*
-
-So this code is valid: `\CodeInline[bash]{cd ${TMP%xy}z && make test_inline}` 
+*Note: special chars should be escaped* 
 
 ## Section macros
 

--- a/test.tex
+++ b/test.tex
@@ -86,7 +86,7 @@ La suite, avec des touches \keys{CTRL + A}. Et on peut avoir une ligne avec
 
 \horizontalLine
 
-Voici un peu de code inline: \CodeInline[bash]{make test}. Et voici quelques exemples de code python :
+Voici un peu de code inline: \CodeInline{make test}. Et voici quelques exemples de code python :
 
 \begin{CodeBlock}{python}
 def foo(bar):

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -364,7 +364,7 @@
    coltitle=defaultColor
 }
 
-\DeclareTotalTCBox{\CodeInline}{ O{text} v }{%
+\DeclareTotalTCBox{\CodeInline}{m}{%
    verbatim,
    enlarge top initially by=0mm,
    enlarge bottom finally by=0mm,
@@ -374,7 +374,7 @@
    boxrule=0.5pt,
    arc=0.0pt
 }
-{\mintinline{#1}{#2}}
+{\texttt{#1}}
 
 %%% IFRAMES
 \newenvironment{Iframe}[1]{%

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -18,7 +18,7 @@
 \RequirePackage{newfloat}
 \RequirePackage{ifthen}
 \RequirePackage{xifthen}
-\usepackage{luacode}
+\RequirePackage{luacode}
 
 %% LATEX 3 PACKAGES
 \RequirePackage{etoolbox}


### PR DESCRIPTION
inlineCode cause trouble with special char (due to mintinline).
inlineCode use now `texttt` instead of `mintinline` and special char need to be escaped.