### PR TITLE
enhancement/special-blocks: Add support of neutral block

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -51,23 +51,23 @@ Create a inline source code with `\CodeInline{make test}`.
 
 The different title levels get adapted depending on the class option used.
 
-| | `small` | `middle` | `big` |
-|-|---------|----------------|-----|
-|`\levelOneTitle` | `\section` | `\chapter` | `\part`|
-|`\levelTwoTitle` | `\subsection` | `\section` | `\chapter`|
-|`\levelThreeTitle` | `\subsubsection` | `\subsection` | `\section`|
-|`\levelFourTitle`| `\paragraph` | `\subsubsection` | `\subsection` |
-|`\levelFiveTitle` |  `\subparagraph` | `\paragraph` | `\subsubsection`|
-|`\levelSixTitle` | *n.a.* |  `\subparagraph` | `\paragraph` |
-|`\levelSevenTitle` | *n.a.* | *n.a.* |  `\subparagraph`|
+|                    | `small`          | `middle`         | `big`            |
+| ------------------ | ---------------- | ---------------- | ---------------- |
+| `\levelOneTitle`   | `\section`       | `\chapter`       | `\part`          |
+| `\levelTwoTitle`   | `\subsection`    | `\section`       | `\chapter`       |
+| `\levelThreeTitle` | `\subsubsection` | `\subsection`    | `\section`       |
+| `\levelFourTitle`  | `\paragraph`     | `\subsubsection` | `\subsection`    |
+| `\levelFiveTitle`  | `\subparagraph`  | `\paragraph`     | `\subsubsection` |
+| `\levelSixTitle`   | *n.a.*           | `\subparagraph`  | `\paragraph`     |
+| `\levelSevenTitle` | *n.a.*           | *n.a.*           | `\subparagraph`  |
 
 For introduction and conclusion, macros are also defined. They don’t take parameters and they are titled "Introduction" / "Conclusion".
 
-| | `small` | `middle` | `big` |
-|-|---------|----------------|-----|
-|`\levelOneIntroduction` and `\levelOneConclusion` | Document introduction/conclusion | Document introduction/conclusion | Document introduction/conclusion|
-|`\levelTwoIntroduction` and `\levelOneConclusion` | *n.a.* | Chapter introduction/conclusion | Part introduction/conclusion|
-|`\levelThreeIntroduction` and `\levelThreeConclusion` | *n.a.* | *n.a.* | Chapter introduction/conclusion |
+|                                          | `small`                          | `middle`                         | `big`                            |
+| ---------------------------------------- | -------------------------------- | -------------------------------- | -------------------------------- |
+| `\levelOneIntroduction` and `\levelOneConclusion` | Document introduction/conclusion | Document introduction/conclusion | Document introduction/conclusion |
+| `\levelTwoIntroduction` and `\levelOneConclusion` | *n.a.*                           | Chapter introduction/conclusion  | Part introduction/conclusion     |
+| `\levelThreeIntroduction` and `\levelThreeConclusion` | *n.a.*                           | *n.a.*                           | Chapter introduction/conclusion  |
 
 ## Title page macros (`\website`, `\authorlink`, `\editor`, `\editorLogo` and `\logo`)
 
@@ -103,6 +103,16 @@ Arguments in square brackets are optional (`\iframe{url}` is enough). The defaul
 ## `Information`, `Question`, `Warning` and `Error`
 
 Mimic the corresponding markdown blocks.
+
+It can take an optional parameter that corresponding to the block title.
+
+Example:
+
+```latex
+\begin{Question}[My optional title]
+Content of my block
+\end{Question}
+```
 
 ## Quotes
 

--- a/test.tex
+++ b/test.tex
@@ -170,6 +170,14 @@ def foo(bar):
 \blindtext
 \end{Error}
 
+\begin{Information}[Titre d'une information méga importante]
+\blindtext
+\end{Information}
+
+\begin{Neutral}[Titre de mon bloc neutre]
+Un bloc neutre, pour contenir un théorème ou une équation par exemple.
+\end{Neutral}
+
 Et finalement, un tableau:
 
 \begin{longtabu}{|c|c|c|} \hline

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -138,6 +138,12 @@
 \definecolor{ZdSBoxBorderError}{HTML}{\iftoggle{nocolor}{4D4D4D}{D9C5C5}}
 \definecolor{ZdSBoxLogoBackgroundError}{HTML}{\iftoggle{nocolor}{808080}{C21936}}
 
+% NEUTRAL
+\definecolor{ZdSBoxForegroundNeutral}{HTML}{\iftoggle{nocolor}{424242}{424242}}
+\definecolor{ZdSBoxBackgroundNeutral}{HTML}{\iftoggle{nocolor}{FFFFFF}{FFFFFF}}
+\definecolor{ZdSBoxBorderNeutral}{HTML}{\iftoggle{nocolor}{4D4D4D}{4D4D4D}}
+\definecolor{ZdSBoxLogoBackgroundNeutral}{HTML}{\iftoggle{nocolor}{808080}{808080}}
+
 % SPOILER
 \definecolor{ZdSBoxForegroundSpoiler}{HTML}{555555}
 \definecolor{ZdSBoxBackgroundSpoiler}{HTML}{EEEEEE}
@@ -294,28 +300,35 @@
 %%% DEFAULT BOX THEME
 
 \tcbsetforeverylayer{%
+   enhanced,
    enlarge top initially by=5mm,
    boxrule=0.5pt,
    breakable,
-   enhanced,
-   attach boxed title to top center={yshift=-2mm},
-   arc=0.0pt
+   arc=0.0pt,
 }
 
-\newcommand{\newBox}[6]{%
-   \newtcolorbox{#1}{
+\NewDocumentCommand\newBox{m m m m m o}{%
+   \DeclareTColorBox{#1}{ o }{
       colback=#2,
       coltext=#3,
       colframe=#4,
-      overlay={\node at (frame.north west) {\createBoxIcon{#5}{#6}};}
+      colbacktitle=#5,
+      titlerule=0mm,
+      IfValueTF={##1}{title=##1}{},
+      overlay={
+         \IfValueTF{#6}
+         {\node at (frame.north west) {\createBoxIcon{#5}{#6}};}
+         {}
+      }
    }%
 }
 
-\newBox{Success}{ZdSBoxBackgroundSuccess}{ZdSBoxForegroundSuccess}{ZdSBoxBorderSuccess}{ZdSBoxLogoBackgroundSuccess}{\checkmark}
-\newBox{Information}{ZdSBoxBackgroundInformation}{ZdSBoxForegroundInformation}{ZdSBoxBorderInformation}{ZdSBoxLogoBackgroundInformation}{i}
-\newBox{Question}{ZdSBoxBackgroundQuestion}{ZdSBoxForegroundQuestion}{ZdSBoxBorderQuestion}{ZdSBoxLogoBackgroundQuestion}{?}
-\newBox{Warning}{ZdSBoxBackgroundWarning}{ZdSBoxForegroundWarning}{ZdSBoxBorderWarning}{ZdSBoxLogoBackgroundWarning}{!}
-\newBox{Error}{ZdSBoxBackgroundError}{ZdSBoxForegroundError}{ZdSBoxBorderError}{ZdSBoxLogoBackgroundError}{\times}
+\newBox{Success}{ZdSBoxBackgroundSuccess}{ZdSBoxForegroundSuccess}{ZdSBoxBorderSuccess}{ZdSBoxLogoBackgroundSuccess}[\checkmark]
+\newBox{Information}{ZdSBoxBackgroundInformation}{ZdSBoxForegroundInformation}{ZdSBoxBorderInformation}{ZdSBoxLogoBackgroundInformation}[i]
+\newBox{Question}{ZdSBoxBackgroundQuestion}{ZdSBoxForegroundQuestion}{ZdSBoxBorderQuestion}{ZdSBoxLogoBackgroundQuestion}[?]
+\newBox{Warning}{ZdSBoxBackgroundWarning}{ZdSBoxForegroundWarning}{ZdSBoxBorderWarning}{ZdSBoxLogoBackgroundWarning}[!]
+\newBox{Error}{ZdSBoxBackgroundError}{ZdSBoxForegroundError}{ZdSBoxBorderError}{ZdSBoxLogoBackgroundError}[\times]
+\newBox{Neutral}{ZdSBoxBackgroundNeutral}{ZdSBoxForegroundNeutral}{ZdSBoxBorderNeutral}{ZdSBoxLogoBackgroundNeutral}
 
 %%% QUOTATION
 \DeclareTColorBox{Quotation}{ o }{%


### PR DESCRIPTION
Related to [zmarkdown#184](https://github.com/zestedesavoir/zmarkdown/issues/184), add support of titled block and neutral block.

Example: [test.pdf](https://github.com/zestedesavoir/latex-template/files/1713891/test.pdf)
