### PR TITLE
Use soul instead of tcolorbox for inline code

### DIFF
--- a/scripts/packages
+++ b/scripts/packages
@@ -38,3 +38,4 @@ luacode
 ctablestack
 luatex85
 grffile
+soul

--- a/tests/test.tex
+++ b/tests/test.tex
@@ -87,7 +87,7 @@ La suite, avec des touches \keys{CTRL + A}. Et on peut avoir une ligne avec
 
 \horizontalLine
 
-Voici un peu de code inline: \CodeInline{make test}. Plus ? Plus : \CodeInline{# ceci est une ligne de code incroyablement longue, comme ça elle passe sur plusieurs lignes}.
+Voici un peu de code inline: \CodeInline{make test}. Plus ? Plus : \CodeInline{\# ceci est une ligne de code incroyablement longue, comme ça elle passe sur plusieurs lignes}.
 
 
 Et voici quelques exemples de code python :

--- a/tests/test.tex
+++ b/tests/test.tex
@@ -87,7 +87,10 @@ La suite, avec des touches \keys{CTRL + A}. Et on peut avoir une ligne avec
 
 \horizontalLine
 
-Voici un peu de code inline: \CodeInline{make test}. Et voici quelques exemples de code python :
+Voici un peu de code inline: \CodeInline{make test}. Plus ? Plus : \CodeInline{# ceci est une ligne de code incroyablement longue, comme ça elle passe sur plusieurs lignes}.
+
+
+Et voici quelques exemples de code python :
 
 \begin{CodeBlock}{python}
 def foo(bar):

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{zmdocument}
 
-\LoadClass[fontsize=12pt,twoside=false,numbers=enddot,parskip=half]{scrbook}
+\LoadClass[a4paper,fontsize=12pt,twoside=false,numbers=enddot,parskip=half]{scrbook}
 
 %%% PACKAGES -------------------------------------------------------------------
 
@@ -260,6 +260,10 @@
 \addtokomafont{subparagraph}{\color{subparagraphColor}}
 
 \setcounter{secnumdepth}{4}
+
+%%% GEOMETRY -----------------------------------------------------------------
+
+\newgeometry{top=2.5cm, bottom=2.5cm, right=2cm,left=2cm}
 
 %%% CUSTOMS ENVIRONMENTS AND MACROS ------------------------------------------
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -20,6 +20,7 @@
 \RequirePackage{ifthen}
 \RequirePackage{xifthen}
 \RequirePackage{luacode}
+\RequirePackage{soul}
 
 %% LATEX 3 PACKAGES
 \RequirePackage{etoolbox}
@@ -379,17 +380,8 @@
    coltitle=defaultColor
 }
 
-\DeclareTotalTCBox{\CodeInline}{m}{%
-   verbatim,
-   enlarge top initially by=0mm,
-   enlarge bottom finally by=0mm,
-   colback=codeBackgroundColor,
-   coltext=defaultColor,
-   colframe=ZdSBoxBorderSpoiler,
-   boxrule=0.5pt,
-   arc=0.0pt
-}
-{\texttt{#1}}
+\sethlcolor{codeBackgroundColor}
+\newcommand{\CodeInline}[1]{\hl{\texttt{#1}}}
 
 %%% IFRAMES
 \newenvironment{Iframe}[1]{%


### PR DESCRIPTION
because `\hl` splits over multiple lines.