### PR TITLE
We can copy code without the line numbers

### DIFF
--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -11,6 +11,7 @@
 \RequirePackage[dvipsnames,table]{xcolor}
 \RequirePackage{scrlayer-scrpage}
 \RequirePackage{minted}
+\RequirePackage{accsupp}
 \RequirePackage{amsmath,amssymb}
 \RequirePackage[french]{babel}
 \RequirePackage[babel=true]{microtype}
@@ -356,7 +357,11 @@
 
 \setminted{breaklines, breaksymbolleft=\hspace{2em}, highlightcolor=highlightCodeColor, linenos, fontsize=\small,baselinestretch=1}
 
-\renewcommand\theFancyVerbLine{\small\textcolor{lineNumberCodeColor}{\arabic{FancyVerbLine}}}
+\renewcommand\theFancyVerbLine{%
+   \BeginAccSupp{ActualText={}}%
+      \small\textcolor{lineNumberCodeColor}{\arabic{FancyVerbLine}}%
+   \EndAccSupp{}%
+}
 
 \DeclareTCBListing{CodeBlock}{O{}O{}O{1}m}{%
    enlarge top initially by=5mm,


### PR DESCRIPTION
Related to [this topic](https://zestedesavoir.com/forums/sujet/12603/copier-coller-de-code-depuis-les-exports-pdf/)
Solution found on [here](https://tex.stackexchange.com/a/30793)