### PR TITLE
Fix bug : code in spoiler

### DIFF
--- a/tests/test.tex
+++ b/tests/test.tex
@@ -1,15 +1,15 @@
-\documentclass[small]{zmdocument}
+\documentclass[small]{zmdocumentdd}
 
 \usepackage{blindtext}
 
 \title{Ceci est un titre}
 \author{Karnaj, pierre\_24, Heziode, Clem}
-\licence[./test-images/cc-by-nc-nd_icon.svg]{CC-BY-NC-ND}{https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode}
+\licence[test-images/cc-by-nc-nd_icon.svg]{CC-BY-NC-ND}{https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode}
 
-\logo{./test-images/tuto_logo.png}
-\editorLogo[La connaissance pour tous et sans pépins]{./test-images/zestedesavoir.svg}
+\logo{test-images/tuto_logo.png}
+\editorLogo[La connaissance pour tous et sans pépins]{test-images/zestedesavoir.svg}
 
-\smileysPath{./test-smileys}
+\smileysPath{test-smileys}
 \makeglossaries
 
 \begin{document}
@@ -150,12 +150,12 @@ Bien sûr, on peut écrire des maths, et on peut même leur mettre une légende.
 
 Une image hors-texte :
 
-\image{./test-images/logo.png}[Légende de l’image]
+\image{test-images/logo.png}[Légende de l’image]
 
-On peut aussi avoir une image dans le texte \inlineImage{./test-images/tuto_logo.png}, mais dans ce cas, pas de légende.
+On peut aussi avoir une image dans le texte \inlineImage{test-images/tuto_logo.png}, mais dans ce cas, pas de légende.
 
 \begin{center}
-\includegraphics[width=\linewidth]{./test-images/logo.png}
+\includegraphics[width=\linewidth]{test-images/logo.png}
 \captionof{figure}{Légende}
 \end{center}
 
@@ -243,7 +243,7 @@ def test(a):
 Et une image:
 
 \begin{center}
-\includegraphics[width=\linewidth]{./test-images/logo.png}
+\includegraphics[width=\linewidth]{test-images/logo.png}
 \captionof{figure}{Légende}
 \end{center}
 
@@ -285,7 +285,7 @@ C\textsubscript{6}H\textsubscript{6}, \textsuperscript{13}C ,
 \keys{CTRL + A},
 \CodeInline{du code},
 \abbr{CQFD}{Ce qu'il fallait démontrer},
-\inlineImage{./test-smileys/clin.png}
+\inlineImage{test-smileys/clin.png}
 }
 
 \end{document}

--- a/tests/test.tex
+++ b/tests/test.tex
@@ -52,6 +52,18 @@ Voici un autre secret.
 \end{itemize}
 
 \begin{Spoiler}
+\begin{CodeBlock}{text}
+Test
+\end{CodeBlock}
+\end{Spoiler}
+
+\begin{Spoiler}[Secret avec code et titre]
+\begin{CodeBlock}{text}
+Test
+\end{CodeBlock}
+\end{Spoiler}
+
+\begin{Spoiler}
 Voici un dernier secret.
 \end{Spoiler}
 

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -428,7 +428,8 @@
       \color{defaultColor}
    }
    \end{SpoilerBox}%
-   \begingroup\tcbverbatimwrite{\spoilerFileName{\the@spoilerCounter}}}{
+   \begingroup\tcbverbatimwrite{\spoilerFileName{\the@spoilerCounter}}\%
+}{
    \endtcbverbatimwrite\endgroup
    \listgadd{\@spoilerList}{\IfNoValueTF{#1}{}{#1}}%
    \addtocounter{@spoilerCounter}{1}


### PR DESCRIPTION
Now, this code compiles.

```latex
\begin{Spoiler}
\begin{CodeBlock}{text}
Test
\end{CodeBlock}
\end{Spoiler}
```.
