### PR TITLE
Fix error with includegraphics

### DIFF
--- a/scripts/packages
+++ b/scripts/packages
@@ -35,3 +35,4 @@ ctablestack
 luatex85
 soul
 catchfile
+accsupp

--- a/scripts/packages
+++ b/scripts/packages
@@ -36,3 +36,4 @@ luatex85
 soul
 catchfile
 accsupp
+letltxmacro

--- a/scripts/packages
+++ b/scripts/packages
@@ -34,3 +34,4 @@ luacode
 ctablestack
 luatex85
 soul
+catchfile

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -42,6 +42,7 @@
 \RequirePackage{epstopdf}
 \RequirePackage{geometry}
 \RequirePackage{grffile}
+\let\quote@name\unquote@name % Fix grffile 
 
 \epstopdfDeclareGraphicsRule{.gif}{png}{.png}{convert gif:#1 png:\OutputFile}
 \AppendGraphicsExtensions{.gif}


### PR DESCRIPTION
[grffile does not work with LuaLaTeX (error with `\includegraphics`)](https://github.com/ho-tex/grffile/issues/1). Fix it with [this solution](https://github.com/ho-tex/grffile/issues/1#issuecomment-543101052).