### PR TITLE
Fix chapter numbering

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,6 +24,8 @@ author-test: test-author.pdf
 
 images-test: test-with-images.pdf
 
+big-test: test-big.pdf
+
 create-nocolor:
 	cp test.tex test-nocolor.tex
 	patch test-nocolor.tex < nocolor.patch
@@ -35,7 +37,7 @@ test-nocolor.pdf: test-nocolor.tex
 
 nocolor-test: create-nocolor test-nocolor.pdf
 
-tests: simple-test author-test images-test nocolor-test
+tests: simple-test author-test images-test nocolor-test big-test
 
 clean:
 	rm -f test-nocolor.tex

--- a/tests/test-big.tex
+++ b/tests/test-big.tex
@@ -1,0 +1,19 @@
+\documentclass[big]{zmdocument}
+
+\title{Ceci est un titre}
+\author{Auteur}
+
+\begin{document}
+\tableofcontents
+\newpage
+
+\levelOneIntroduction
+
+\levelOneTitle{Partie Un}
+   \levelTwoTitle{Chapitre Un}
+   \levelTwoTitle{Chapitre Deux}
+
+\levelOneTitle{Partie Un}
+   \levelTwoTitle{Chapitre Un}
+   \levelTwoTitle{Chapitre Deux}
+\end{document}

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -250,6 +250,7 @@
    \newcommand{\levelThreeIntroduction}{\addsec{Introduction}}
    \newcommand{\levelThreeConclusion}{\addsec{Conclusion}}
    \automark[chapter]{part}
+   \counterwithin{chapter}{part}
 }
 
 %%% PROCESSING

--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -249,8 +249,8 @@
    \newcommand{\levelTwoConclusion}{\displaySpoilers \addchap{Conclusion}}
    \newcommand{\levelThreeIntroduction}{\addsec{Introduction}}
    \newcommand{\levelThreeConclusion}{\addsec{Conclusion}}
-   \automark[chapter]{part}
    \counterwithin{chapter}{part}
+   \automark[chapter]{part}
 }
 
 %%% PROCESSING


### PR DESCRIPTION
Fix #109. Now, we have this numbering with `test-big.tex`...
```
Part I
  Chapter I.1
  Chapter I.2
Part II
  Chapter II.1
  Chapter II.2
```
Instead of this one.
```
Part I
  Chapter 1
  Chapter 2
Part II
  Chapter 3
  Chapter 4
```
