### PR TITLE
Switch from tabu to tabularray

### DIFF
--- a/zmdocument.cls
+++ b/zmdocument.cls
@@ -32,9 +32,7 @@
 \RequirePackage{pagecolor}
 
 %%% TABLE PACKAGES
-\RequirePackage{multirow}
-\RequirePackage{longtable}
-\RequirePackage{tabu}
+\RequirePackage{tabularray}
 
 %%% GRAPHIC PACKAGES
 \RequirePackage{graphicx}
@@ -592,6 +590,18 @@
    \displayAppendices
    \printglossary[title=Liste des abréviations]
 }
+
+%%% TABLES
+% Remove default caption
+\DefTblrTemplate{contfoot-text}{default}{}
+\DefTblrTemplate{conthead-text}{default}{}
+\DefTblrTemplate{caption}{default}{}
+\DefTblrTemplate{conthead}{default}{}
+\DefTblrTemplate{capcont}{default}{}
+
+\NewTblrEnviron{zdstblr}
+\SetTblrInner[zdstblr]{hlines,vlines,hspan=minimal}
+\SetTblrOuter[zdstblr]{long}
 
 %%% TITLE PAGE
 


### PR DESCRIPTION
## Purpose

Fixes #135 
Fixes #137 

## Changes

* Include `tabularray` package
* Remove `tabu` and side packages: `tabularray` does not require `multirow` nor `longtable`
* Define a custom `zdstblr` environment

## Related changes

https://github.com/zestedesavoir/zmarkdown/pull/500 depends on this PR

To allow testing without installing a full ZMarkdown and renderer, I am including a Markdown example containing both a simple and a complex table, the LaTeX result and image of the PDF document obtained when compiling with the new template.

```markdown
# Simple table

| Header 1 | Header 2 | Header 3 | Header 4 |
| -------- | -------- | -------- | -------- |
| Cell 1   | Cell 2   | Cell 3   | Cell 4   |
| Cell 5   | Cell 6   | Cell 7   | Cell 8   |

# Complex table

+-------+----------+------+
| Table Headings   | Here |
+-------+----------+------+
| Sub   | Headings | Too  |
+=======+==========+======+
| cell  | column spanning |
+ spans +----------+------+
| rows  | normal   | cell |
+-------+----------+------+
| multi | cells can be    |
| line  | *formatted*     |
|       | **paragraphs**  |
| cells |                 |
| too   |                 |
+-------+-----------------+
```

```latex
\documentclass[small]{zmdocument}
\begin{document}
	\levelOneTitle{Simple table}

	\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\bfseries}}
		Header 1 & Header 2 & Header 3 & Header 4 \\
		Cell 1 & Cell 2 & Cell 3 & Cell 4 \\
		Cell 5 & Cell 6 & Cell 7 & Cell 8 \\
	\end{zdstblr}

	\levelOneTitle{Complex table}

	\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=2,row{1,2}={font=\bfseries}}
		\SetCell[c=2]{l} Table Headings &  & Here \\
		Sub & Headings & Too \\
		\SetCell[r=2]{l} cell \endgraf spans \endgraf rows & \SetCell[c=2]{l} column spanning &  \\
		 & normal & cell \\
		multi \endgraf line \endgraf \endgraf cells \endgraf too & \SetCell[c=2]{l} cells can be \endgraf \textit{formatted} \endgraf \textbf{paragraphs} &  \\
	\end{zdstblr}
\end{document}
```

![Rendering of the LaTeX code above](https://github.com/zestedesavoir/latex-template/assets/6739422/08d3e591-7a25-4ee7-8425-bc7baafc4b03)

## Open questions

Before merging, I would like to know if what I did is correct, both on LaTeX and ZMarkdown sides, especially:

- is using `X[-1]` everywhere, instead of the previous weird formula, right?
- I think this is linked but am unsure: our tables used to take only the required width, now they are fullpage tables. First, which of the two behaviors do we want? Second, if we want to restore the previous behavior, how can this be done?
- should we fine-tune some parameters on tabularray environment? I used very basic parameters, but am sure you may come up with way better things;
- finally, do we used to support captions for tables? I am not even sure it can be done in the Markdown. If it is the case, then a way to remove the caption only when it is empty needs to be found, and we might also want to move it to the bottom of the table, while `tabularray` has it on the top by default.